### PR TITLE
Schedule the controller on masters

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,12 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
       securityContext:
         runAsUser: 1000730000
       containers:


### PR DESCRIPTION
Scheduling this controller on masters makes sense in the world of
fencing where remediation controllers take action on nodes and reboot
them. During the reboot time we want this controller to be running all
the time to keep track of the node condition and to keep monitoring for
nodes health. Otherwise a controller running on a node that reboots may
fail to reconcile the other nodes health meanwhile.
Since masters are a more rare case for fencing this choice should reduce
this case dramtically.

Change-Id: Icda66935414092155f641c27f6056a987cb94084
Signed-off-by: Roy Golan <rgolan@redhat.com>