### PR TITLE
Set the coresponding NHC and not Node as the ownerReference

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -296,10 +296,10 @@ func (r *NodeHealthCheckReconciler) generateRemediationCR(n v1.Node, nhc remedia
 	})
 	u.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion:         n.APIVersion,
-			Kind:               n.Kind,
-			Name:               n.Name,
-			UID:                n.UID,
+			APIVersion:         nhc.APIVersion,
+			Kind:               nhc.Kind,
+			Name:               nhc.Name,
+			UID:                nhc.UID,
 			Controller:         pointer.BoolPtr(false),
 			BlockOwnerDeletion: nil,
 		},

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -165,8 +165,9 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(o.Object).To(ContainElement(map[string]interface{}{"size": "foo"}))
 				Expect(o.GetOwnerReferences()).
 					To(ContainElement(metav1.OwnerReference{
-						Kind:       "Node",
-						Name:       "unhealthy-node-1",
+						Kind:       underTest.Kind,
+						APIVersion: underTest.APIVersion,
+						Name:       underTest.Name,
 						Controller: pointer.BoolPtr(false),
 					}))
 			})


### PR DESCRIPTION
This behaviour change means that EMR is only deleted when the node
appears healthy.

Motivation:
 - we can't set the node as the owner reference, otherwise a node
   deletion removes the EMR, while the remediation isn't done yet.
   A node with the same name may be added and that will mark a good end
   for the remediation process.
- escalation: keeping the EMR the node appears healthy means that if it
  does't then the remediation failed and the provider can take other
  actions.

Modification:
 - remove the Node from the EMR ownerReference
 - add the NHC to the EMR ownerReference

Change-Id: Ie42b501e95bfb1f7c1a08dbace39fe895582d84d
Signed-off-by: Roy Golan <rgolan@redhat.com>