### PR TITLE
Add an aggregation rule for the ClusterRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,12 @@ spec:
 
 ## Remediation Providers responsibility
 
-- it is upto the remediation provider to delete the external remediation object if the node is deleted and another is
+  It is upto the remediation provider to delete the external remediation object if the node is deleted and another is
   reprovisioned. In that specific scenario the controller can not assume a successful node remediation because the
   node with that name doesn't exist, and instead there will be a new one.
 
+### RBAC rules aggregation
+
+Each provider must label it's rules with `rbac.ext-remediation/aggregate-to-ext-remediation: true` so the controller
+will aggreate its rules and will have the proper permission to create/delete external remediation objects
+  each 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -29,6 +29,7 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
+- manager_aggregation_role_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_aggregation_role_patch.yaml
+++ b/config/default/manager_aggregation_role_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.ext-remediation/aggregate-to-ext-remediation: "true"


### PR DESCRIPTION
This will aggregate rbac rules of every provider so the controller will
be able to create/delete ExternalRemediaitonTemplate whenever a provider
is setting up its API

Change-Id: I95b9f19a13c184dbb714e3e0a2257a125e278c16
Signed-off-by: Roy Golan <rgolan@redhat.com>