### PR TITLE
Add another ClusterRole for the aggregation

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -29,7 +29,8 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
-- manager_aggregation_role_patch.yaml
+- manager_role_patch.yaml
+- manager_aggregator_role_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_aggregator_role_patch.yaml
+++ b/config/default/manager_aggregator_role_patch.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: manager-role-aggregator
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/config/default/manager_role_patch.yaml
+++ b/config/default/manager_role_patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    rbac.ext-remediation/aggregate-to-ext-remediation: "true"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - role.yaml
 - role_binding.yaml
+- role_aggregator.yaml
+- role_aggregator_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/role_aggregator.yaml
+++ b/config/rbac/role_aggregator.yaml
@@ -1,0 +1,8 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role-aggregator
+rules:

--- a/config/rbac/role_aggregator_binding.yaml
+++ b/config/rbac/role_aggregator_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-aggregator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role-aggregator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system


### PR DESCRIPTION
Aggregation swaps the included rules in a role and swaps them with
whatever is aggregator. There for another role with the basic rules is
needed.

Change-Id: Ia5e9e4216712b896206e9e8dbf043554309a7b7a
Signed-off-by: Roy Golan <rgolan@redhat.com>