### PR TITLE
Fix resource fetch to plural form, otherwise this fails

### DIFF
--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Node Health Check CR", func() {
 			It("create a remediation CR for each unhealthy node", func() {
 				Expect(reconcileError).NotTo(HaveOccurred())
 				cr := newRemediationCR("unhealthy-node-1")
-				o, err := reconciler.DynamicClient.Resource(remediationResource(cr)).
+				o, err := reconciler.DynamicClient.Resource(crToResource(cr)).
 					Namespace(cr.GetNamespace()).
 					Get(context.Background(), cr.GetName(), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -243,14 +243,14 @@ var _ = Describe("Node Health Check CR", func() {
 
 				cr := newRemediationCR("unhealthy-node-1")
 				_, err := reconciler.DynamicClient.
-					Resource(remediationResource(cr)).
+					Resource(crToResource(cr)).
 					Namespace(cr.GetNamespace()).
 					Get(context.Background(), cr.GetName(), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				cr = newRemediationCR("unhealthy-node-2")
 				_, err = reconciler.DynamicClient.
-					Resource(remediationResource(cr)).
+					Resource(crToResource(cr)).
 					Namespace(cr.GetNamespace()).
 					Get(context.Background(), cr.GetName(), metav1.GetOptions{})
 				Expect(errors.IsNotFound(err)).To(BeTrue())
@@ -361,14 +361,6 @@ var _ = Describe("Node Health Check CR", func() {
 		})
 	})
 })
-
-func remediationResource(u unstructured.Unstructured) schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    u.GroupVersionKind().Group,
-		Version:  u.GroupVersionKind().Version,
-		Resource: strings.ToLower(u.GetKind()),
-	}
-}
 
 func newRemediationCR(nodeName string) unstructured.Unstructured {
 	cr := unstructured.Unstructured{}


### PR DESCRIPTION
Api resources are plural, when using the kind value to understand the
resources just add 's' for plural.

context: when fetching remediation objects we don't know have the
resource name but only the template kind (i.e
PoisonPillRemediationTemplate) so the resource must be
poisonpillremediations.
This can work but RBAC rules usually specify the resource
name, which is plural and not singular form.


Change-Id: Iae06668964d3c779a7f320c16e3e67389e68e3c5
Signed-off-by: Roy Golan <rgolan@redhat.com>
