### PR TITLE
Add e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ testbin/*
 *.swp
 *.swo
 *~
+testdata/.remediators/

--- a/e2e/E2E-Tests.md
+++ b/e2e/E2E-Tests.md
@@ -1,0 +1,29 @@
+Run `make test-e2e` on an existing cluster to test the current HEAD of
+NHC with poison-pill.
+
+Prerequisite:
+ - cluster with at least 2 workers which are rebootable (k8s or OCP)
+ - available kubeconfig ($HOME/.kube/config or export KUBECONFIG if needed)
+ - container image of the current NHC version in a registry
+   (openshift-ci does that as a dependency. manuall invocation should
+   use make docker-build docker-push)
+
+Goals:
+ - Test end-to-end the HEAD of the current repo with Poison-Pill
+ - Use Poison-Pill image that is pinned in its master branch. (can be
+   changed using PPIL_GIT_REF)
+
+Non-Goals:
+ - Plugablle structure for new remediators
+
+The order of actions is roughly:
+ - create a k8s client
+ - download latest poison pill git repo
+ - make deploy poison pill
+ - create a remediation template resource
+ - make deploy NHC using current $IMG (where IMG is a based on current git HASH)
+ - provision a basic NHC resource with PP resource reference
+ - run go tests to test behavior
+    - fail a host, see its picked up NHC and PP, watch the node come back healthy
+    - fail a host which is not under NHC selector, see it's untouched
+

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,0 +1,147 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2e Suite")
+}
+
+var (
+	dynamicClient         dynamic.Interface
+	clientSet             *kubernetes.Clientset
+	poisonPillTemplateGVR = schema.GroupVersionResource{
+		Group:    "poison-pill.medik8s.io",
+		Version:  "v1alpha1",
+		Resource: "poisonpillremediationtemplates",
+	}
+	poisonPillRemediationGVR = schema.GroupVersionResource{
+		Group:    "poison-pill.medik8s.io",
+		Version:  "v1alpha1",
+		Resource: "poisonpillremediations",
+	}
+	nhcGVR = schema.GroupVersionResource{
+		Group:    v1alpha1.GroupVersion.Group,
+		Version:  v1alpha1.GroupVersion.Version,
+		Resource: "nodehealthchecks",
+	}
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// +kubebuilder:scaffold:scheme
+
+	// get the client or die
+	getConfig, err := config.GetConfig()
+	if err != nil {
+		Fail(fmt.Sprintf("Couldn't get kubeconfig %v", err))
+	}
+	clientSet, err = kubernetes.NewForConfig(getConfig)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clientSet).NotTo(BeNil())
+
+	dynamicClient, err = dynamic.NewForConfig(getConfig)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(dynamicClient).NotTo(BeNil())
+
+	debug()
+
+	Expect(createPoisonPillTemplate()).To(Succeed())
+	Expect(createNHCResources()).To(Succeed())
+}, 10)
+
+func createNHCResources() error {
+	maxUnhealthy := intstr.Parse("49%")
+	nhc := v1alpha1.NodeHealthCheck{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodeHealthCheck",
+			APIVersion: v1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.NodeHealthCheckSpec{
+			Selector: metav1.LabelSelector{},
+			UnhealthyConditions: []v1alpha1.UnhealthyCondition{
+				{
+					Type:     v1.NodeReady,
+					Status:   v1.ConditionUnknown,
+					Duration: metav1.Duration{Duration: time.Second * 20},
+				},
+			},
+			MaxUnhealthy: &maxUnhealthy,
+			RemediationTemplate: &v1.ObjectReference{
+				Kind:       "PoisonPillRemediationTemplate",
+				APIVersion: "poison-pill.medik8s.io/v1alpha1",
+				Name:       "poison-pill-template",
+				Namespace:  testNamespace,
+			},
+		},
+	}
+	toUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&nhc)
+	fmt.Println(toUnstructured)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = dynamicClient.
+		Resource(nhcGVR).
+		Create(
+			context.Background(),
+			&unstructured.Unstructured{Object: toUnstructured},
+			metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func debug() {
+	version, _ := clientSet.ServerVersion()
+	fmt.Fprint(GinkgoWriter, version)
+}
+
+func createPoisonPillTemplate() error {
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "PoisonPillRemediationTemplate",
+			"apiVersion": "poison-pill.medik8s.io/v1alpha1",
+			"metadata": map[string]interface{}{
+				"name": "poison-pill-template",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+	_, err := dynamicClient.Resource(poisonPillTemplateGVR).Namespace(testNamespace).Create(context.Background(), &obj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,155 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	blockingPodName               = "api-blocker-pod"
+	safeToAssumeNodeRebootTimeout = 180 * time.Second
+	testNamespace                 = "default"
+)
+
+var _ = Describe("e2e", func() {
+	var nodeUnderTest *v1.Node
+
+	BeforeEach(func() {
+		// randomly pick a host (or let the scheduler do it by running the blocking pod)
+		// block the api port to make it go Ready Unknown
+		nodeName, err := makeNodeUnready(time.Minute * 5)
+		Expect(err).NotTo(HaveOccurred())
+		nodeUnderTest, err = clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	AfterEach(func() {
+		removeAPIBlockingPod()
+	})
+	When("Node conditions meets the unhealthy criteria", func() {
+		It("Remediates a host", func() {
+			Eventually(
+				fetchNHCByName(nodeUnderTest.Name), 2*time.Minute, 5*time.Second).
+				Should(Succeed())
+			Eventually(
+				nodeCreationTime(nodeUnderTest.Name), safeToAssumeNodeRebootTimeout+30*time.Second, 250*time.Millisecond).
+				Should(BeTemporally(">", nodeUnderTest.GetCreationTimestamp().Time))
+		})
+	})
+})
+
+func nodeCreationTime(nodeName string) func() time.Time {
+	return func() time.Time {
+		n, err := clientSet.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return time.Now()
+		}
+		return n.GetCreationTimestamp().Time
+	}
+}
+
+func fetchNHCByName(name string) func() error {
+	return func() error {
+		get, err := dynamicClient.Resource(poisonPillRemediationGVR).Namespace(testNamespace).
+			Get(context.Background(),
+				name,
+				metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(GinkgoWriter, "found a ppil object %v  that should remediate node %v\n", get.GetName(), name)
+		return nil
+	}
+}
+
+//makeNodeUnready puts a node in an unready condition by disrupting the network
+// for the duration passed
+func makeNodeUnready(duration time.Duration) (string, error) {
+	// run a privileged pod that blocks the api port
+
+	directory := v1.HostPathDirectory
+	var p = v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: blockingPodName},
+		Spec: v1.PodSpec{
+			// for running iptables in the host namespace
+			HostNetwork: true,
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser:  pointer.Int64Ptr(0),
+				RunAsGroup: pointer.Int64Ptr(0),
+			},
+			Containers: []v1.Container{{
+				Env: []v1.EnvVar{{
+					Name:  "SLEEPDURATION",
+					Value: fmt.Sprintf("%v", duration.Seconds()),
+				}},
+				Name:  "main",
+				Image: "registry.access.redhat.com/ubi8/ubi-minimal",
+				Command: []string{
+					"/bin/bash",
+					"-c",
+					`#!/bin/bash -ex
+microdnf install iptables
+port=$(awk -F[\:] '/server\:/ {print $NF}' /etc/kubernetes/kubeconfig 2>/dev/null || awk -F[\:] '/server\:/ {print $NF}' /etc/kubernetes/kubelet.conf)
+iptables -A OUTPUT -p tcp --dport ${port} -j REJECT
+sleep ${SLEEPDURATION}
+iptables -D OUTPUT -p tcp --dport ${port} -j REJECT
+sleep infinity
+`,
+				},
+				VolumeMounts: []v1.VolumeMount{{
+					Name:      "etckube",
+					MountPath: "/etc/kubernetes",
+				}},
+				SecurityContext: &v1.SecurityContext{
+					Privileged:               pointer.BoolPtr(true),
+					AllowPrivilegeEscalation: pointer.BoolPtr(true),
+				},
+			}},
+			Volumes: []v1.Volume{{
+				Name: "etckube",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/etc/kubernetes",
+						Type: &directory,
+					},
+				},
+			}},
+		},
+	}
+
+	_, err := clientSet.CoreV1().
+		Pods(testNamespace).
+		Create(context.Background(), &p, metav1.CreateOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to run the api-blocker pod")
+	}
+	var runsOnNode string
+	err = wait.Poll(5*time.Second, 60*time.Second, func() (done bool, err error) {
+		get, err := clientSet.CoreV1().Pods(testNamespace).Get(context.Background(), blockingPodName, metav1.GetOptions{})
+		fmt.Fprint(GinkgoWriter, "attempting to run a pod to block the api port\n")
+		if err != nil {
+			return false, err
+		}
+		if get.Status.Phase == v1.PodRunning {
+			runsOnNode = get.Spec.NodeName
+			fmt.Fprint(GinkgoWriter, "API blocker pod is running\n")
+			return true, nil
+		}
+		return false, nil
+	})
+	return runsOnNode, err
+}
+
+func removeAPIBlockingPod() {
+	clientSet.CoreV1().Pods(testNamespace).Delete(context.Background(), blockingPodName, metav1.DeleteOptions{})
+}


### PR DESCRIPTION
Add e2e tests (run with make test-e2e)
    
    Run `make test-e2e` on an existing cluster to test the current HEAD of
    NHC with poison-pill.
    
    Prerequisite:
     - cluster with at least 2 workers which are rebootable (k8s or OCP)
     - available kubeconfig ($HOME/.kube/config or export KUBECONFIG if needed)
    
    Goals:
     - Use the HEAD of the current repo (means we prepare and push NHC image ad
       hoc)
     - Use Poison Pill image that is pinned in its master branch. (can be
       changed using PPIL_GIT_REF)
    
    Non-Goals:
     - Plugablle structure for new remediators
    
    The order of actions is roughly:
     - create a k8s client
     - download latest poison pill git repo
     - make deploy poison pill
     - create a remediation template resource
     - produce NHC image and push to some repo
       (when running in openshift-ci then push to internal registry otherwise quay)
     - make deploy NHC using current $IMG (where IMG is a based on current git HASH)
     - provision a basic NHC resource with PP resource reference
     - run go tests to test behavior
        - fail a host, see its picked up NHC and PP, watch the node come back healthy
        - fail a host which is not under NHC selector, see it's untouched
    
    Creating ppil config and CR:
    A deployed poison-pill doesn't currently mean its running.
    In order for this to happen there's a small section
    that runs in BeforeSuite (a ginkgo function) that
    creates the poison-pill Config CR and creates a poison pill template.
    
    Future poison-pill work should create the config CR by default
    https://github.com/medik8s/poison-pill/pull/33
