### PR TITLE
Update the default condition with Ready|Unknown

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -34,7 +34,7 @@ type NodeHealthCheckSpec struct {
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
 	// +optional
-	// +kubebuilder:default:={{type:Ready,status:False,duration:"300s"}}
+	// +kubebuilder:default:={{type:Ready,status:False,duration:"300s"},{type:Ready,status:Unknown,duration:"300s"}}
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
 	// Any farther remediation is only allowed if at most "MaxUnhealthy" nodes selected by

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -117,6 +117,9 @@ spec:
                 - duration: 300s
                   status: "False"
                   type: Ready
+                - duration: 300s
+                  status: Unknown
+                  type: Ready
                 description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
                 items:
                   description: UnhealthyCondition represents a Node condition type and value with a specified duration. When the named condition has been in the given status for at least the duration value a node is considered unhealthy.

--- a/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
+++ b/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nodehealthcheck-sample
 spec:
 #  optional
-  selector:                                     # 1)
+  selector:
     matchLabels:
       kubernetes.io/os: linux
 #    optionally use more fine grained matching
@@ -14,12 +14,15 @@ spec:
 #        values:
 #          - another-node-label-value
 
-  maxUnhealthy: "49%"                          # 2)
-  unhealthyConditions:                         # 3)
+  maxUnhealthy: "49%"
+  unhealthyConditions:
     - type: Ready
       status: False
       duration: 300s
-  remediationTemplate:                 # 4)
+    - type: Ready
+      status: Unknown
+      duration: 300s
+  remediationTemplate:
     kind: ProviderXRemedyTemplate
     apiVersion: medik8s.io/v1alpha1
     name: group-x

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -61,11 +61,14 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(underTest.Namespace).To(BeEmpty())
 			})
 
-			It("sets a default condition Unready 300s", func() {
-				Expect(underTest.Spec.UnhealthyConditions).To(HaveLen(1))
+			It("sets a default conditions", func() {
+				Expect(underTest.Spec.UnhealthyConditions).To(HaveLen(2))
 				Expect(underTest.Spec.UnhealthyConditions[0].Type).To(Equal(v1.NodeReady))
 				Expect(underTest.Spec.UnhealthyConditions[0].Status).To(Equal(v1.ConditionFalse))
 				Expect(underTest.Spec.UnhealthyConditions[0].Duration).To(Equal(metav1.Duration{Duration: time.Minute * 5}))
+				Expect(underTest.Spec.UnhealthyConditions[1].Type).To(Equal(v1.NodeReady))
+				Expect(underTest.Spec.UnhealthyConditions[1].Status).To(Equal(v1.ConditionUnknown))
+				Expect(underTest.Spec.UnhealthyConditions[1].Duration).To(Equal(metav1.Duration{Duration: time.Minute * 5}))
 			})
 
 			It("sets max unhealthy to 49%", func() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,9 @@ spec:
 #    - type: Ready
 #      status: False
 #      duration: 300s
+#    - type: Ready
+#      status: Unknown
+#      duration: 300s
 
 ```
 
@@ -67,7 +70,7 @@ spec:
 | _remediationTemplate_ | yes | n/a | A reference to a remediation template provided by an infrastructure provider. If a node needs remediation the controller will create an object from this template and then it should be picked up by a remediation provider.|
 | _selector_ | no | empty selector that selects all nodes | a nodes selector of type [metav1.LabelSelector](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#LabelSelector) | 
 | _maxUnhealthy_ | no | 49% | Any farther remediation is only allowed if at most "MaxUnhealthy" nodes selected by "selector" are not healthy.| 
-| _unhealthyConditions_ | no | `[{type: Ready, status: False, duration: 300s}]` | list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.|
+| _unhealthyConditions_ | no | `[{type: Ready, status: False, duration: 300s},{type: Ready, status: Unknown, duration: 300s}]` | list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.|
 
 ## NodeHealthCheck life-cycle
 


### PR DESCRIPTION
Unknwon is a very common condition when a node is unhealthy and NHC
should use it as a default condition in addition to Ready|False

[ECOPROJECT-122](https://issues.redhat.com/browse/ECOPROJECT-122)

Change-Id: I26ef9da8ddb45f2f369878bb96673df91fd4a765
Signed-off-by: Roy Golan <rgolan@redhat.com>
