### PR TITLE
Make NHC operational on start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./controllers -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./controllers -coverprofile cover.out -v -ginkgo.v
 
 test-mutation: verify-no-changes fetch-mutation ## Run mutation tests in manual mode.
 	echo -e "## Verifying diff ## \n##Mutations tests actually changes the code while running - this is a safeguard in order to be able to easily revert mutation tests changes (in case mutation tests have not completed properly)##"
@@ -85,7 +85,7 @@ uninstall: manifests kustomize
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build $${KUSTOMIZE_OVERLAY-config/default} | $(KUBECTL) apply -f -
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
 undeploy:
@@ -167,17 +167,19 @@ PHONY: test-e2e
 test-e2e:
 	@test -n "${KUBECONFIG}" -o -r ${HOME}/.kube/config || (echo "Failed to find kubeocnfig in ~/.kube/config or no KUBECONFIG set"; exit 1)
 	#TODO not sure needed @if [ -z ${PPIL_IMG} ]; then echo "[WARN] PPIL_IMG is not set"; fi
-	$(MAKE) deploy
+	$(MAKE) deploy KUSTOMIZE_OVERLAY=config/overlays/e2e
 	$(MAKE) deploy-poison-pill
-	go test ./e2e -coverprofile cover.out
+	go test ./e2e -coverprofile cover.out -v -timeout 15m
 
 # Deploy poison-pill to a running cluster
 .PHONY: deploy-poison-pill
 PPIL_DIR = $(shell pwd)/testdata/.remediators/poison-pill
-PPIL_GIT_REF ?= v0.0.6
-PPIL_IMG ?= quay.io/medik8s/poison-pill-operator:0.0.6
+PPIL_GIT_REF ?= ab2fe35
+PPILL_VERSION ?= 0.1.2-11-gab2fe35
 deploy-poison-pill:
 	mkdir -p ${PPIL_DIR}
 	test -f ${PPIL_DIR}/Makefile || curl -L https://github.com/medik8s/poison-pill/tarball/${PPIL_GIT_REF} | tar -C ${PPIL_DIR} -xzv --strip=1
-	$(MAKE) -C ${PPIL_DIR} deploy IMG=${PPIL_IMG}
+	# must override IMG because openshift CI overrides IMG as well.
+	# must override VERSION because this makefile has VERSION and ppill uses the env variable for substition in the deploy
+	$(MAKE) -C ${PPIL_DIR} deploy IMG=quay.io/medik8s/poison-pill-operator:$(PPILL_VERSION) VERSION=$(PPILL_VERSION)
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,11 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+          - name: DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/overlays/e2e/custom-env.yaml
+++ b/config/overlays/e2e/custom-env.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager 
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    spec:
+      containers:
+        - name: manager 
+          env:
+            - name: DEPLOYMENT_NAMESPACE
+              value: poison-pill
+              valueFrom:
+                $patch: delete
+

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../default
+
+patchesStrategicMerge:
+  - custom-env.yaml

--- a/controllers/start.go
+++ b/controllers/start.go
@@ -1,0 +1,120 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// DefaultCRName is the name of default NHC resource the controller creates in case
+// there are no others already.
+const DefaultCRName = "nhc-worker-default"
+
+// DefaultPoisonPillTemplateName is the name of the poison-pill template the default
+// NHC uses.
+const DefaultPoisonPillTemplateName = "poison-pill-default-template"
+
+// NewNodeHealthcheckController setups the Node Health Check controller
+// with the controller manager and ensures at least one NHC resource exists.
+// If there is no NHC resource it will create one with the name in #DefaultCRName
+// that works with poison-pill template by the name in #DefaultPoisonPillTemplateName
+// on the same namespace this controller is deployed.
+func NewNodeHealthcheckController(mgr manager.Manager) error {
+	if err := (&NodeHealthCheckReconciler{
+		Client: mgr.GetClient(),
+		// the dynamic client is here only because the fake client from client-go
+		// couldn't List correctly unstructuredList. The fake dynamic client works.
+		// See https://github.com/kubernetes-sigs/controller-runtime/issues/702
+		DynamicClient: dynamic.NewForConfigOrDie(mgr.GetConfig()),
+		Log:           ctrl.Log.WithName("controllers").WithName("NodeHealthCheck"),
+		Scheme:        mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		return errors.Wrap(err, "unable to create controller")
+	}
+	ns, err := getDeploymentNamespace()
+	if err != nil {
+		return errors.Wrap(err, "unable to get the deployment namespace")
+	}
+	if err = createDefaultNHC(mgr, ns); err != nil {
+		return errors.Wrap(err, "failed to create a default NHC resource")
+	}
+	return nil
+}
+
+// getDeploymentNamespace returns the Namespace this operator is deployed on.
+func getDeploymentNamespace() (string, error) {
+	// deployNamespaceEnvVar is the constant for env variable DEPLOYMENT_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	var deployNamespaceEnvVar = "DEPLOYMENT_NAMESPACE"
+
+	ns, found := os.LookupEnv(deployNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
+	}
+	return ns, nil
+}
+
+func createDefaultNHC(mgr ctrl.Manager, namespace string) error {
+	list := remediationv1alpha1.NodeHealthCheckList{}
+	var err error
+	stop := make(chan struct{})
+	wait.Until(func() {
+		err = mgr.GetAPIReader().List(
+			context.Background(),
+			&list,
+			&client.ListOptions{},
+		)
+		if err == nil {
+			close(stop)
+		}
+	}, time.Minute*1, stop)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to list NHC objects")
+	}
+	if len(list.Items) > 0 {
+		// if we have already some NHC then this is a restart, an upgrade, or a redeploy
+		// then we preserve whatever we have.
+		ctrl.Log.Info("there are existing NHC resources, skip creating a default one", "numOfNHC", len(list.Items))
+		return nil
+	}
+	nhc := remediationv1alpha1.NodeHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: DefaultCRName,
+		},
+		Spec: remediationv1alpha1.NodeHealthCheckSpec{
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "node-role.kubernetes.io/worker",
+					Operator: metav1.LabelSelectorOpExists,
+				}},
+			},
+			RemediationTemplate: &v1.ObjectReference{
+				Kind:       "PoisonPillRemediationTemplate",
+				APIVersion: "poison-pill.medik8s.io/v1alpha1",
+				Name:       DefaultPoisonPillTemplateName,
+				Namespace:  namespace,
+			},
+		},
+	}
+
+	err = mgr.GetClient().Create(context.Background(), &nhc, &client.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, "failed to create a default node-healthcheck resource")
+	}
+	ctrl.Log.Info("created a default NHC resource", "name", DefaultCRName)
+	return nil
+}

--- a/controllers/start_test.go
+++ b/controllers/start_test.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Node Health Check controller", func() {
+	When("the controller starts", func() {
+		It("creates a default NHC resource", func() {
+			nhcs := v1alpha1.NodeHealthCheckList{}
+			err := k8sClient.List(context.Background(), &nhcs, &client.ListOptions{
+				Namespace: "",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nhcs.Items).To(HaveLen(1))
+			Expect(nhcs.Items[0].Name).To(Equal(DefaultCRName))
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,10 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -39,6 +41,7 @@ import (
 
 var cfg *rest.Config
 var k8sClient client.Client
+var k8sManager manager.Manager
 var testEnv *envtest.Environment
 
 const (
@@ -73,15 +76,25 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	scheme.AddToScheme(scheme.Scheme)
 	err = remediationv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
+	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	os.Setenv("DEPLOYMENT_NAMESPACE", "default")
+	err = NewNodeHealthcheckController(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+	go func() {
+		err := k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,13 +23,27 @@ larger clusters, we want to protect against failures that appear to take out
 large portions of compute capacity but are really the result of failures on or
 near the control plane.
 
-For this reason, the healthcheck CR includes the ability to define a percentage
-or total number of nodes that can be considered candidates for concurrent
-remediation.
+For this reason, the [healthcheck CR](#nodehealthcheck-custom-resource) includes
+the ability to define a percentage or total number of nodes that can be
+considered candidates for concurrent remediation.
+
+When the controller starts it will create a default [healthcheck CR](#nodehealthcheck-custom-resource),
+if there is no healthcheck CR at all in the cluster already(supporting upgrades
+with existing configurations). The default CR works with [poison-pill], that
+should be installed automatically if you deployed using the [operator hub].
+The CR uses all defaults except a selector to select only worker nodes.
+
+## Installation
+
+Install the Node Healthcheck operator using [operator hub]. The installation
+will also install the [poison-pill] operator as a default remediator.
+
+For development environments you can run `make deploy deploy-poison-pill`.
+See the [Makefile](./Makefile) for more variables.
 
 ## NodeHealthCheck Custom Resource
 
-Here is an example defintion of the resourcee
+Here is an example definition of the resource
 
 ```yaml
 apiVersion: remediation.medik8s.io/v1alpha1
@@ -149,3 +163,6 @@ spec: {}
 Each provider must label it's rules with `rbac.ext-remediation/aggregate-to-ext-remediation: true` so the controller
 will aggreate its rules and will have the proper permission to create/delete external remediation objects
   each 
+
+[operator hub]: https://operatorhub.io/operator/node-healthcheck-operator
+[poison-pill]: https://github.com/medik8s/poison-pill

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,22 +1,13 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -68,80 +59,9 @@ var _ = BeforeSuite(func() {
 	Expect(dynamicClient).NotTo(BeNil())
 
 	debug()
-
-	Expect(createPoisonPillTemplate()).To(Succeed())
-	Expect(createNHCResources()).To(Succeed())
 }, 10)
-
-func createNHCResources() error {
-	maxUnhealthy := intstr.Parse("49%")
-	nhc := v1alpha1.NodeHealthCheck{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "NodeHealthCheck",
-			APIVersion: v1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
-		Spec: v1alpha1.NodeHealthCheckSpec{
-			Selector: metav1.LabelSelector{},
-			UnhealthyConditions: []v1alpha1.UnhealthyCondition{
-				{
-					Type:     v1.NodeReady,
-					Status:   v1.ConditionUnknown,
-					Duration: metav1.Duration{Duration: time.Second * 20},
-				},
-			},
-			MaxUnhealthy: &maxUnhealthy,
-			RemediationTemplate: &v1.ObjectReference{
-				Kind:       "PoisonPillRemediationTemplate",
-				APIVersion: "poison-pill.medik8s.io/v1alpha1",
-				Name:       "poison-pill-template",
-				Namespace:  testNamespace,
-			},
-		},
-	}
-	toUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&nhc)
-	fmt.Println(toUnstructured)
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = dynamicClient.
-		Resource(nhcGVR).
-		Create(
-			context.Background(),
-			&unstructured.Unstructured{Object: toUnstructured},
-			metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
-}
 
 func debug() {
 	version, _ := clientSet.ServerVersion()
 	fmt.Fprint(GinkgoWriter, version)
-}
-
-func createPoisonPillTemplate() error {
-	obj := unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "PoisonPillRemediationTemplate",
-			"apiVersion": "poison-pill.medik8s.io/v1alpha1",
-			"metadata": map[string]interface{}{
-				"name": "poison-pill-template",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{},
-				},
-			},
-		},
-	}
-	_, err := dynamicClient.Resource(poisonPillTemplateGVR).Namespace(testNamespace).Create(context.Background(), &obj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/client-go/dynamic"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -83,16 +82,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.NodeHealthCheckReconciler{
-		Client: mgr.GetClient(),
-		// the dynamic client is here only because the fake client from client-go
-		// couldn't List correctly unstructuredList. The fake dynamic client works.
-		// See https://github.com/kubernetes-sigs/controller-runtime/issues/702
-		DynamicClient: dynamic.NewForConfigOrDie(mgr.GetConfig()),
-		Log:           ctrl.Log.WithName("controllers").WithName("NodeHealthCheck"),
-		Scheme:        mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "NodeHealthCheck")
+	if err = controllers.NewNodeHealthcheckController(mgr); err != nil {
+		setupLog.Error(err, "controller", "NodeHealthcheckController")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
MOTIVATION
Make NHC operational on start without user actions.

MODIFICATION
Now that NHC is installed by default with poison-pill we make it
operational by creating a default worker-only NHC object that points to
a poison-pill remediation template.
Do note that the reconciler doesn't validate if a remediation template
by the supplied GVK exists. It only uses the GVK when actually creating
the remediation CR.
The responsibility of creating the default expected poison-pill template
is on the poison-pill operator.

RESULT
The opeartor will create an NHC CR for workers only with the defualt
spec parameters, and some default poison-pill remediation template.
If there is some NHC CR that exists then nothing changes - to support
upgrades/restarts.

[ECOPROJECT-166](https://issues.redhat.com/browse/ECOPROJECT-166)

Change-Id: I972a96985d41804f5e489fbe83055ff9c7d0d35a
Signed-off-by: Roy Golan <rgolan@redhat.com>
