### PR TITLE
Use ubi8/ubi-micro instead of gcr image

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -23,6 +25,9 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Test container build
+      run: make docker-build
 
     - name: TestMutations
       run: make test-mutation-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ COPY metrics/ metrics/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
Use Red Hat's universal base image for containers, and gain
security scans on the image in quay.io registry.

Change-Id: Ib6c87dc77949039194acc035a560de00f3e215f2
Signed-off-by: Roy Golan <rgolan@redhat.com>
