### PR TITLE
Tag $VERSION-latest container images based on the version tag

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -30,4 +30,4 @@ jobs:
         run: make docker-build bundle-build
 
       - name: Push to Quay.io
-        run: make docker-push bundle-push
+        run: make docker-push docker-push-latest

--- a/Makefile
+++ b/Makefile
@@ -181,3 +181,9 @@ deploy-poison-pill:
 	test -f ${PPIL_DIR}/Makefile || curl -L https://github.com/medik8s/poison-pill/tarball/${PPIL_GIT_REF} | tar -C ${PPIL_DIR} -xzv --strip=1
 	$(MAKE) -C ${PPIL_DIR} deploy IMG=${PPIL_IMG}
 
+docker-push-latest: IMG_ORIG:=$(IMG)
+docker-push-latest: VERSION=$(shell git describe --abbrev=0 | sed 's/v//')-latest
+docker-push-latest:
+	podman tag $(IMG_ORIG) $(IMG)
+	$(MAKE) docker-push IMG=$(IMG)
+


### PR DESCRIPTION
This change enables creating a 'latest' container tag based on latest
tag. i.e if the current VERSION is 0.0.2-5-glk8wer then this will tag
this version with 0.0.2-latest and push the container image.

Change-Id: Ifbadd942decd8c03ee46024a39c8183b2670da18
Signed-off-by: Roy Golan <rgolan@redhat.com>
