### PR TITLE
Add version info on start

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/medik8s/node-healthcheck-operator/pkg/version"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -68,6 +69,8 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	setupLog.Info(version.String())
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -83,7 +86,7 @@ func main() {
 	}
 
 	if err = controllers.NewNodeHealthcheckController(mgr); err != nil {
-		setupLog.Error(err, "controller", "NodeHealthcheckController")
+		setupLog.Error(err, "controller failed to start")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// goVersion is a constant representing the Go runtime version
+	goVersion string = runtime.Version()
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit = "unknown"
+	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+	// state of git tree, either "clean" or "dirty"
+	gitTreeState string
+)
+
+func String() string {
+	return fmt.Sprintf("goVersion: %s, commitFromGit: %s, versoinFromGit: %s, buildDate: %s, gitTreeState: %s",
+		goVersion, commitFromGit, versionFromGit, buildDate, gitTreeState)
+}


### PR DESCRIPTION
The Makefile part was mostly copied from what library-go endorse [1]
Also the version pkg, with a small a addition of the go version.

The first log message after the logger is set looks like this:
    2021-08-09T09:03:37.991+0300    INFO    setup   goVersion: go1.16.6, commitFromGit: 809e0d3, versoinFromGit: 0.1.0-6-g809e0d3, buildDate: 2021-08-09T06:03:32Z, gitTreeState: dirty

Change-Id: I5d4751e460619f026dd34f6ca46f5f3561f68501
Signed-off-by: Roy Golan <rgolan@redhat.com>
