### PR TITLE
Revert new label, it breaks updates

### DIFF
--- a/bundle/manifests/node-healthcheck-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/node-healthcheck-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app: node-healthcheck-operator
     control-plane: controller-manager
   name: node-healthcheck-operator-controller-manager-metrics-service
 spec:
@@ -12,7 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app: node-healthcheck-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/node-healthcheck-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/node-healthcheck-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,8 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  labels:
-    app: node-healthcheck-operator
   name: node-healthcheck-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -209,13 +209,11 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app: node-healthcheck-operator
               control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                app: node-healthcheck-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
-  labels:
-    app: node-healthcheck-operator
   name: nodehealthchecks.remediation.medik8s.io
 spec:
   group: remediation.medik8s.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,13 @@ namespace: node-healthcheck-operator-system
 namePrefix: node-healthcheck-operator-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: node-healthcheck-operator
+#
+# *** STOP! ***
+# Adding labels breaks updates, because the label selector in the deployment is immutable,
+# and OLM does not deal with it by creating a new deployment instead.
+#
+# commonLabels:
+#   app: node-healthcheck-operator
 
 bases:
 - ../crd


### PR DESCRIPTION
Deployments label selectors are immutable, but OLM does try to update,
instead of creating a new deployment.
