### PR TITLE
Update GitHub Action

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Build and push CSV 0.0.1 + latest images, for pushes
         if: ${{ github.ref_type != 'tag' }}
-        run: make docker-build bundle bundle-build docker-push bundle-push index-build index-push
+        run: make container-build container-push
 
       - name: Build and push versioned CSV and images, for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make docker-build bundle bundle-build docker-push bundle-push index-build index-push
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build container-push

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
+
     - name: Build
       run: make manager
 

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -29,7 +29,7 @@ jobs:
       run: make test
 
     - name: Test container build
-      run: make docker-build
+      run: make container-build
 
     - name: TestMutations
       run: make test-mutation-ci

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,6 @@ test-mutation: verify-no-changes fetch-mutation ## Run mutation tests in manual 
 	echo -e "## Verifying diff ## \n##Mutations tests actually changes the code while running - this is a safeguard in order to be able to easily revert mutation tests changes (in case mutation tests have not completed properly)##"
 	./hack/test-mutation.sh
 
-test-mutation-ci: fetch-mutation ## Run mutation tests as part of auto build process.
-	./hack/test-mutation.sh
 
 # Build manager binary
 manager: generate fmt vet
@@ -284,3 +282,17 @@ deploy-snr:
 	mkdir -p ${SNR_DIR}
 	test -f ${SNR_DIR}/Makefile || curl -L https://github.com/medik8s/self-node-remediation/tarball/${SNR_GIT_REF} | tar -C ${SNR_DIR} -xzv --strip=1
 	$(MAKE) -C ${SNR_DIR} docker-build docker-push deploy VERSION=$(SNR_VERSION)
+
+##@ Targets used by CI
+
+.PHONY: container-build
+container-build: ## Build containers
+	make docker-build bundle bundle-build
+
+.PHONY: container-push
+container-push:  ## Push containers (NOTE: catalog can't be build before bundle was pushed)
+	make docker-push bundle-push index-build index-push
+
+.PHONY: test-mutation-ci
+test-mutation-ci: fetch-mutation ## Run mutation tests as part of auto build process.
+	./hack/test-mutation.sh


### PR DESCRIPTION
- Updating GitHub Action versions (similar to [NMO PR](https://github.com/medik8s/node-maintenance-operator/pull/24) and [SNR PR](https://github.com/medik8s/self-node-remediation/pull/13)):
  - [actions/checkout](https://github.com/actions/checkout/tree/main) and  [actions/setup-go](https://github.com/actions/setup-go/tree/main) versions from 2 to 3.
  - [docker/login-action](https://github.com/docker/login-action) from version 1 to 2.
- Adding two new targets (`container-build` & `container-push`) for CI in Makefile.
