### PR TITLE
update PP to SNR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,14 +275,12 @@ test-e2e:
 	@test -n "${KUBECONFIG}" -o -r ${HOME}/.kube/config || (echo "Failed to find kubeconfig in ~/.kube/config or no KUBECONFIG set"; exit 1)
 	go test ./e2e -coverprofile cover.out -v -timeout 15m
 
-# Deploy poison-pill to a running cluster
-.PHONY: deploy-poison-pill
-PPIL_DIR = $(shell pwd)/testdata/.remediators/poison-pill
-PPIL_GIT_REF ?= v0.1.4
-PPILL_VERSION ?= 0.1.4
-deploy-poison-pill:
-	mkdir -p ${PPIL_DIR}
-	test -f ${PPIL_DIR}/Makefile || curl -L https://github.com/medik8s/poison-pill/tarball/${PPIL_GIT_REF} | tar -C ${PPIL_DIR} -xzv --strip=1
-	# must override IMG because openshift CI overrides IMG as well.
-	# must override VERSION because this makefile has VERSION and ppill uses the env variable for substition in the deploy
-	$(MAKE) -C ${PPIL_DIR} deploy IMG=quay.io/medik8s/poison-pill-operator:$(PPILL_VERSION) VERSION=$(PPILL_VERSION)
+# Deploy self node remediation to a running cluster
+.PHONY: deploy-snr
+SNR_DIR = $(shell pwd)/testdata/.remediators/snr
+SNR_GIT_REF ?= main
+SNR_VERSION ?= 0.0.1
+deploy-snr:
+	mkdir -p ${SNR_DIR}
+	test -f ${SNR_DIR}/Makefile || curl -L https://github.com/medik8s/self-node-remediation/tarball/${SNR_GIT_REF} | tar -C ${SNR_DIR} -xzv --strip=1
+	$(MAKE) -C ${SNR_DIR} docker-build docker-push deploy VERSION=$(SNR_VERSION)

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -14,9 +14,9 @@ metadata:
           "spec": {
             "minHealthy": "51%",
             "remediationTemplate": {
-              "apiVersion": "poison-pill.medik8s.io/v1alpha1",
-              "kind": "PoisonPillRemediationTemplate",
-              "name": "poison-pill-default-template",
+              "apiVersion": "self-node-remediation.medik8s.io/v1alpha1",
+              "kind": "SelfNodeRemediationTemplate",
+              "name": "self-node-remediation-resource-deletion-template",
               "namespace": "openshift-operators"
             },
             "selector": {
@@ -46,9 +46,9 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/node-healthcheck-operator:latest
     createdAt: ""
-    description: An operator to monitor node healthcheck and remdiate via 3rd party
-      providers like poison-pill.
-    olm.skipRange: '>=0.1.0 <0.2.0'
+    description: An operator to monitor node healthcheck and remediate via 3rd party
+      providers like Self Node Remediation.
+    olm.skipRange: '>=0.2.0 <0.3.0'
     operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/node-healthcheck-operator
@@ -316,8 +316,8 @@ spec:
     type: AllNamespaces
   keywords:
   - NHC
-  - Poison Pill
-  - PP
+  - Self Node Remediation
+  - SNR
   - Remediation
   - Fencing
   - medik8s

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - type: olm.gvk
   value:
-    group: poison-pill.medik8s.io 
-    kind: PoisonPillRemediation
+    group: self-node-remediation.medik8s.io
+    kind: SelfNodeRemediation
     version: v1alpha1

--- a/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -7,9 +7,9 @@ metadata:
     categories: OpenShift Optional
     containerImage: ""
     createdAt: ""
-    description: An operator to monitor node healthcheck and remdiate via 3rd party
-      providers like poison-pill.
-    olm.skipRange: '>=0.1.0 <0.2.0'
+    description: An operator to monitor node healthcheck and remediate via 3rd party
+      providers like Self Node Remediation.
+    olm.skipRange: '>=0.2.0 <0.3.0'
     repository: https://github.com/medik8s/node-healthcheck-operator
     support: Medik8s
   name: node-healthcheck-operator.v0.0.0
@@ -98,8 +98,8 @@ spec:
     type: AllNamespaces
   keywords:
   - NHC
-  - Poison Pill
-  - PP
+  - Self Node Remediation
+  - SNR
   - Remediation
   - Fencing
   - medik8s

--- a/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
+++ b/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
@@ -27,7 +27,7 @@ spec:
       status: Unknown
       duration: 300s
   remediationTemplate:
-    kind: PoisonPillRemediationTemplate
-    apiVersion: poison-pill.medik8s.io/v1alpha1
-    name: poison-pill-default-template
+    apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    kind: SelfNodeRemediationTemplate
+    name: self-node-remediation-resource-deletion-template
     namespace: openshift-operators

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -25,8 +25,8 @@ func Initialize(mgr ctrl.Manager, log logr.Logger) error {
 		return errors.Wrap(err, "failed to create or update RBAC aggregation role")
 	}
 
-	if err = defaults.CreateDefaultNHC(mgr, ns, ctrl.Log.WithName("defaults")); err != nil {
-		return errors.Wrap(err, "failed to create a default NHC resource")
+	if err = defaults.CreateOrUpdateDefaultNHC(mgr, ns, ctrl.Log.WithName("defaults")); err != nil {
+		return errors.Wrap(err, "failed to create or update a default NHC resource")
 	}
 
 	return nil

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,52 +22,12 @@ $ operator-sdk olm install
     ```
 
 
-By default, OLM will resolve Poison-Pill as a dependency and will install the
+By default, OLM will resolve the Self Node Remediation operator as a dependency and will install the
 latest available version in the current catalog or other catalog with higher
 priority.
 
-## Post install
-
 >NOTE: OLM on k8s install operators under the `operators` namespace while
 >      in OCP or OKD it is under `openshift-operators`
-
-- create a poison pill remediation template
-```shell
-cat << EOF | kubectl create -f -
-apiVersion: poison-pill.medik8s.io/v1alpha1
-kind: PoisonPillRemediationTemplate
-metadata:
-  namespace: default
-  name: ppill-template
-spec:
-  template:
-    spec: {}
-EOF
-```
-
-- create Node-Healthcheck CR that points to poison-pill remediation
-```shell
-cat << EOF | kubectl create -f -
-apiVersion: remediation.medik8s.io/v1alpha1
-kind: NodeHealthCheck
-metadata:
-  namespace: default
-  name: nodehealthcheck-sample
-spec:
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      duration: 300s
-    - type: Ready
-      status: "False"
-      duration: 300s
-  remediationTemplate:
-    kind: PoisonPillRemediationTemplate
-    apiVersion: poison-pill.medik8s.io/v1alpha1
-    name: ppill-template
-    namespace: default
-EOF
-```
 
 Your cluster should have 2 deployments and 1 daemonset:
 
@@ -75,11 +35,11 @@ Your cluster should have 2 deployments and 1 daemonset:
 $ kubectl get deploy -n operators
 NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
 node-healthcheck-operator-controller-manager   1/1     1            1           3m8s
-poison-pill-controller-manager                 1/1     1            1           3m10s
+self-node-remediation-controller-manager       1/1     1            1           3m10s
 
 $ kubectl get ds -n operators
-NAME             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-poison-pill-ds   3         3         3       3            3           <none>          3h6m
+NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+self-node-remediation-ds   3         3         3       3            3           <none>          3h6m
 ```
 
 ### Customizations:

--- a/e2e/E2E-Tests.md
+++ b/e2e/E2E-Tests.md
@@ -1,29 +1,26 @@
 Run `make test-e2e` on an existing cluster to test the current HEAD of
-NHC with poison-pill.
+NHC with Self Node Remediation.
 
 Prerequisite:
- - cluster with at least 2 workers which are rebootable (k8s or OCP)
- - available kubeconfig ($HOME/.kube/config or export KUBECONFIG if needed)
- - container image of the current NHC version in a registry
-   (openshift-ci does that as a dependency. manuall invocation should
-   use make docker-build docker-push)
+- cluster with at least 2 workers which are rebootable (k8s or OCP)
+- available kubeconfig ($HOME/.kube/config or export KUBECONFIG if needed)
+- container image of the current NHC version in a registry
+  (openshift-ci does that as a dependency. manual invocation should
+  use make docker-build docker-push)
 
 Goals:
- - Test end-to-end the HEAD of the current repo with Poison-Pill
- - Use Poison-Pill image that is pinned in its master branch. (can be
-   changed using PPIL_GIT_REF)
+- Test end-to-end the HEAD of the current repo with Self Node Remediation
+- Build, push and use Self Node Remediation image from its main branch
 
 Non-Goals:
- - Plugablle structure for new remediators
+- Plugablle structure for new remediators
 
 The order of actions is roughly:
- - create a k8s client
- - download latest poison pill git repo
- - make deploy poison pill
- - create a remediation template resource
- - make deploy NHC using current $IMG (where IMG is a based on current git HASH)
- - provision a basic NHC resource with PP resource reference
- - run go tests to test behavior
-    - fail a host, see its picked up NHC and PP, watch the node come back healthy
-    - fail a host which is not under NHC selector, see it's untouched
+- create a k8s client
+- download latest self node remediation git repo
+- make docker-build docker-push deploy for self node remediation
+- make deploy NHC using current $IMG (where IMG is a based on current git HASH)
+- run go tests to test behavior
+  - fail a host, see its picked up NHC and SNR, watch the node come back healthy
+  - fail a host which is not under NHC selector, see it's untouched
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -28,18 +28,18 @@ func TestE2e(t *testing.T) {
 }
 
 var (
-	dynamicClient         dynamic.Interface
-	clientSet             *kubernetes.Clientset
-	client                ctrl.Client
-	poisonPillTemplateGVR = schema.GroupVersionResource{
-		Group:    "poison-pill.medik8s.io",
+	dynamicClient          dynamic.Interface
+	clientSet              *kubernetes.Clientset
+	client                 ctrl.Client
+	remediationTemplateGVR = schema.GroupVersionResource{
+		Group:    "self-node-remediation.medik8s.io/v1alpha1",
 		Version:  "v1alpha1",
-		Resource: "poisonpillremediationtemplates",
+		Resource: "selfnoderemediationtemplates",
 	}
-	poisonPillRemediationGVR = schema.GroupVersionResource{
-		Group:    "poison-pill.medik8s.io",
+	remediationGVR = schema.GroupVersionResource{
+		Group:    "self-node-remediation.medik8s.io/v1alpha1",
 		Version:  "v1alpha1",
-		Resource: "poisonpillremediations",
+		Resource: "selfnoderemediations",
 	}
 	nhcGVR = schema.GroupVersionResource{
 		Group:    v1alpha1.GroupVersion.Group,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -184,11 +184,11 @@ func nodeCreationTime(nodeName string) func() time.Time {
 
 func fetchPPRByName(name string) func() error {
 	return func() error {
-		ns, err := getPPRTemplateNS()
+		ns, err := getTemplateNS()
 		if err != nil {
 			return err
 		}
-		get, err := dynamicClient.Resource(poisonPillRemediationGVR).Namespace(ns).
+		get, err := dynamicClient.Resource(remediationGVR).Namespace(ns).
 			Get(context.Background(),
 				name,
 				metav1.GetOptions{})
@@ -200,18 +200,18 @@ func fetchPPRByName(name string) func() error {
 	}
 }
 
-func getPPRTemplateNS() (string, error) {
-	list, err := dynamicClient.Resource(poisonPillTemplateGVR).List(context.Background(), metav1.ListOptions{})
+func getTemplateNS() (string, error) {
+	list, err := dynamicClient.Resource(remediationTemplateGVR).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
 	for _, t := range list.Items {
-		if t.GetName() == "poison-pill-default-template" {
+		if t.GetName() == "self-node-remediation-resource-deletion-template" {
 			return t.GetNamespace(), err
 		}
 	}
 
-	return "", fmt.Errorf("failed to find the default poison-pill template")
+	return "", fmt.Errorf("failed to find the default remediation template")
 }
 
 //makeNodeUnready puts a node in an unready condition by disrupting the network


### PR DESCRIPTION
Poison Pill is deprecated, so update all occurences to Self Node Remediation.
Existing NHC resources refering to the old PP defaut template will also be updated during runtime.

New template name depends on https://github.com/medik8s/self-node-remediation/pull/22

CI config changes for having latest SNR available:
SNR:
https://github.com/openshift/release/pull/29089
https://github.com/openshift/release/pull/29136

NHC:
https://github.com/openshift/release/pull/29101
https://github.com/openshift/release/pull/29140