### PR TITLE
Add phase and reason to status

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -31,6 +31,22 @@ const (
 	ConditionReasonDisabledMHC = "MachineHealthCheckDetected"
 )
 
+type NHCPhase string
+
+const (
+	// PhaseDisabled is used when the Disabled condition is true
+	PhaseDisabled NHCPhase = "Disabled"
+
+	// PhasePaused is used when not disabled, but PauseRequests is set
+	PhasePaused NHCPhase = "Paused"
+
+	// PhaseRemediating is used when not disabled and not paused, and InFlightRemediations is set
+	PhaseRemediating NHCPhase = "Remediating"
+
+	// PhaseEnabled is used in all other cases
+	PhaseEnabled NHCPhase = "Enabled"
+)
+
 // NodeHealthCheckSpec defines the desired state of NodeHealthCheck
 type NodeHealthCheckSpec struct {
 	// Label selector to match nodes whose health will be exercised.
@@ -123,6 +139,20 @@ type NodeHealthCheckStatus struct {
 	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="phase",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// Phase represents the current phase of this Config.
+	// Known phases are Disabled, Paused, Remediating and Enabled, based on:\n
+	// - the status of the Disabled condition\n
+	// - the value of PauseRequests\n
+	// - the value of InFlightRemediations
+	// +optional
+	Phase NHCPhase `json:"phase,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="reason",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// Reason explains the current phase in more detail.
+	// +optional
+	Reason string `json:"reason,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -31,6 +31,7 @@ const (
 	ConditionReasonDisabledMHC = "MachineHealthCheckDetected"
 )
 
+// NHCPhase is the string used for NHC.Status.Phase
 type NHCPhase string
 
 const (

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -118,6 +118,19 @@ spec:
         path: observedNodes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:observedNodes
+      - description: Phase represents the current phase of this Config. Known phases
+          are Disabled, Paused, Remediating and Enabled, based on:\n - the status
+          of the Disabled condition\n - the value of PauseRequests\n - the value of
+          InFlightRemediations
+        displayName: phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Reason explains the current phase in more detail.
+        displayName: reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
   description: This operator deploys the Node Health Check operator
   displayName: Node Health Check Operator

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -289,6 +289,15 @@ spec:
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selecor
                 type: integer
+              phase:
+                description: Phase represents the current phase of this Config. Known
+                  phases are Disabled, Paused, Remediating and Enabled, based on:\n
+                  - the status of the Disabled condition\n - the value of PauseRequests\n
+                  - the value of InFlightRemediations
+                type: string
+              reason:
+                description: Reason explains the current phase in more detail.
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -290,6 +290,15 @@ spec:
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selecor
                 type: integer
+              phase:
+                description: Phase represents the current phase of this Config. Known
+                  phases are Disabled, Paused, Remediating and Enabled, based on:\n
+                  - the status of the Disabled condition\n - the value of PauseRequests\n
+                  - the value of InFlightRemediations
+                type: string
+              reason:
+                description: Reason explains the current phase in more detail.
+                type: string
             type: object
         type: object
     served: true

--- a/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -77,6 +77,19 @@ spec:
         path: observedNodes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:observedNodes
+      - description: Phase represents the current phase of this Config. Known phases
+          are Disabled, Paused, Remediating and Enabled, based on:\n - the status
+          of the Disabled condition\n - the value of PauseRequests\n - the value of
+          InFlightRemediations
+        displayName: phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Reason explains the current phase in more detail.
+        displayName: reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       version: v1alpha1
   description: This operator deploys the Node Health Check operator
   displayName: Node Health Check Operator

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openshift/api/machine/v1beta1"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,25 +31,25 @@ type MachineHealthCheckReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *MachineHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("MachineHealthCheck", req.NamespacedName)
+	//log := r.Log.WithValues("MachineHealthCheck", req.NamespacedName)
 
 	// update MHCChecker status
 	r.MHCChecker.UpdateStatus()
+	result := ctrl.Result{}
 
 	// fetch mhc
-	mhc := &v1beta1.MachineHealthCheck{}
-	err := r.Get(ctx, req.NamespacedName, mhc)
-	result := ctrl.Result{}
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("MachineHealthCheck not found", "name", req.Name, "namespace", req.Namespace)
-			return result, nil
-		}
-		log.Error(err, "failed fetching MachineHealthCheck", "name", req.Name, "namespace", req.Namespace)
-		return result, err
-	}
-
-	log.Info("reconciling MachineHealthCheck", "name", req.Name, "namespace", req.Namespace)
+	//mhc := &v1beta1.MachineHealthCheck{}
+	//err := r.Get(ctx, req.NamespacedName, mhc)
+	//if err != nil {
+	//	if apierrors.IsNotFound(err) {
+	//		log.Info("MachineHealthCheck not found", "name", req.Name, "namespace", req.Namespace)
+	//		return result, nil
+	//	}
+	//	log.Error(err, "failed fetching MachineHealthCheck", "name", req.Name, "namespace", req.Namespace)
+	//	return result, err
+	//}
+	//
+	//log.Info("reconciling MachineHealthCheck", "name", req.Name, "namespace", req.Namespace)
 
 	return result, nil
 }

--- a/controllers/mhc/mhc_checker.go
+++ b/controllers/mhc/mhc_checker.go
@@ -80,10 +80,17 @@ func (c *checker) UpdateStatus() error {
 
 	if len(mhcList.Items) == 0 {
 		// no MHC found, we are fine
+		if c.mhcStatus != noMHC {
+			c.logger.Info("no MHC found")
+		}
 		c.mhcStatus = noMHC
 		return nil
 	} else if len(mhcList.Items) > 1 {
 		// multiple MHCs found, disable NHC
+		// log once only
+		if c.mhcStatus != customMHC {
+			c.logger.Info("found custom MHC, will disable NHC")
+		}
 		c.mhcStatus = customMHC
 		return nil
 	}
@@ -101,6 +108,10 @@ func (c *checker) UpdateStatus() error {
 	}
 
 	// Everything else might cause conflicts
+	// log once only
+	if c.mhcStatus != customMHC {
+		c.logger.Info("found custom MHC, will disable NHC")
+	}
 	c.mhcStatus = customMHC
 	return nil
 

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -80,13 +80,13 @@ type NodeHealthCheckReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := r.Log.WithValues("NodeHealthCheck", req.NamespacedName)
 
 	// fetch nhc
 	nhc := &remediationv1alpha1.NodeHealthCheck{}
-	err := r.Get(ctx, req.NamespacedName, nhc)
-	result := ctrl.Result{}
+	err = r.Get(ctx, req.NamespacedName, nhc)
+	result = ctrl.Result{}
 	if err != nil {
 		log.Error(err, "failed fetching Node Health Check", "object", nhc)
 		if apierrors.IsNotFound(err) {
@@ -95,7 +95,16 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	// check if we need to disable NHC because of existimg MHCs
+	// check if we need to patch status before we exit Reconcile
+	nhcOrig := nhc.DeepCopy()
+	defer func() {
+		err = r.patchStatus(nhc, nhcOrig)
+		if err != nil {
+			log.Error(err, "failed to patch NHC status")
+		}
+	}()
+
+	// check if we need to disable NHC because of existing MHCs
 	if disable := r.MHCChecker.NeedDisableNHC(); disable {
 		// update status if needed
 		if !meta.IsStatusConditionTrue(nhc.Status.Conditions, remediationv1alpha1.ConditionTypeDisabled) {
@@ -107,11 +116,6 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				Message: "Custom MachineHealthCheck(s) detected, disabling NHC to avoid conflicts",
 			})
 			r.Recorder.Eventf(nhc, eventTypeWarning, eventReasonDisabled, "Custom MachineHealthCheck(s) detected, disabling NHC to avoid conflicts")
-			err = r.Client.Status().Update(context.Background(), nhc)
-			if err != nil {
-				log.Error(err, "failed to update NHC status conditions")
-				return result, err
-			}
 		}
 		// stop reconciling
 		return result, nil
@@ -120,11 +124,6 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		log.Info("re-enabling NHC, no conflicting MHC configured in the cluster")
 		meta.RemoveStatusCondition(&nhc.Status.Conditions, remediationv1alpha1.ConditionTypeDisabled)
 		r.Recorder.Eventf(nhc, eventTypeNormal, eventReasonEnabled, "Custom MachineHealthCheck(s) removed, re-enabling NHC")
-		err = r.Client.Status().Update(context.Background(), nhc)
-		if err != nil {
-			log.Error(err, "failed to update NHC status conditions")
-			return result, err
-		}
 	}
 
 	// select nodes using the nhc.selector
@@ -132,12 +131,14 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		return result, err
 	}
+	nhc.Status.ObservedNodes = len(nodes)
 
 	// check nodes health
 	unhealthyNodes, err := r.checkNodesHealth(nodes, nhc)
 	if err != nil {
 		return result, err
 	}
+	nhc.Status.HealthyNodes = len(nodes) - len(unhealthyNodes)
 
 	minHealthy, err := intstr.GetScaledValueFromIntOrPercent(nhc.Spec.MinHealthy, len(nodes), true)
 	if err != nil {
@@ -146,11 +147,14 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
+	var reconcileErr error
 	if r.shouldTryRemediation(nhc, nodes, unhealthyNodes, minHealthy, &result) {
 		for i := range unhealthyNodes {
-			nextReconcile, err := r.remediate(ctx, &unhealthyNodes[i], nhc)
-			if err != nil {
-				return ctrl.Result{}, err
+			var nextReconcile *time.Duration
+			nextReconcile, reconcileErr = r.remediate(ctx, &unhealthyNodes[i], nhc)
+			if reconcileErr != nil {
+				// don't try to remediate other nodes
+				break
 			}
 			if nextReconcile != nil {
 				updateResultNextReconcile(&result, *nextReconcile)
@@ -158,16 +162,17 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// update inFlightRemediations before checking reconcile error
 	inFlightRemediations, err := r.getInflightRemediations(nhc)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed fetching remediation objects of the NHC")
+		return result, errors.Wrapf(err, "failed fetching remediation objects of the NHC")
+	}
+	nhc.Status.InFlightRemediations = inFlightRemediations
+
+	if reconcileErr != nil {
+		return result, reconcileErr
 	}
 
-	err = r.patchStatus(nhc, len(nodes), len(unhealthyNodes), inFlightRemediations)
-	if err != nil {
-		log.Error(err, "failed to patch NHC status")
-		return ctrl.Result{}, err
-	}
 	return result, nil
 }
 
@@ -393,23 +398,14 @@ func (r *NodeHealthCheckReconciler) fetchTemplate(nhc *remediationv1alpha1.NodeH
 	return obj, nil
 }
 
-func (r *NodeHealthCheckReconciler) patchStatus(nhc *remediationv1alpha1.NodeHealthCheck, observedNodes int, unhealthyNodes int, remediations map[string]metav1.Time) error {
-
-	healthyNodes := observedNodes - unhealthyNodes
+func (r *NodeHealthCheckReconciler) patchStatus(nhc, nhcOrig *remediationv1alpha1.NodeHealthCheck) error {
 
 	// skip when no changes
-	if nhc.Status.ObservedNodes == observedNodes &&
-		nhc.Status.HealthyNodes == healthyNodes &&
-		((len(nhc.Status.InFlightRemediations) == 0 && len(remediations) == 0) || reflect.DeepEqual(nhc.Status.InFlightRemediations, remediations)) {
+	if reflect.DeepEqual(nhc.Status, nhcOrig.Status) {
 		return nil
 	}
 
-	base := nhc.DeepCopy()
-	mergeFrom := client.MergeFrom(base)
-
-	nhc.Status.ObservedNodes = observedNodes
-	nhc.Status.HealthyNodes = healthyNodes
-	nhc.Status.InFlightRemediations = remediations
+	mergeFrom := client.MergeFrom(nhcOrig)
 
 	// all values to be patched expected to be updated on the current nhc.status
 	r.Log.Info("Patching NHC object", "patch", nhc.Status)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -93,7 +93,7 @@ var _ = Describe("e2e", func() {
 				Expect(meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
 				Expect(nhcList.Items[0].Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
 				return nil
-			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
 		})
 	})
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -84,14 +84,16 @@ var _ = Describe("e2e", func() {
 		})
 
 		It("should report disabled NHC", func() {
-			Eventually(func() (bool, error) {
+			Eventually(func() error {
 				nhcList := &v1alpha1.NodeHealthCheckList{}
 				Expect(client.List(context.Background(), nhcList)).To(Succeed())
 				if len(nhcList.Items) != 1 {
-					return false, errors.New("less or more than 1 NHC found")
+					return errors.New("less or more than 1 NHC found")
 				}
-				return meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled), nil
-			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "NHC should be disabled because of custom MHC")
+				Expect(meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
+				Expect(nhcList.Items[0].Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
 		})
 	})
 
@@ -111,16 +113,18 @@ var _ = Describe("e2e", func() {
 			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "node should not be terminating")
 
 			// ensure NHC is not disabled from previous test
-			Eventually(func() (bool, error) {
+			Eventually(func() error {
 				nhcList := &v1alpha1.NodeHealthCheckList{}
 				if err := client.List(context.Background(), nhcList); err != nil {
-					return false, err
+					return err
 				}
 				if len(nhcList.Items) != 1 {
-					return false, errors.New("less or more than 1 NHC found")
+					return errors.New("less or more than 1 NHC found")
 				}
-				return meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled), nil
-			}, 1*time.Minute, 5*time.Second).Should(BeFalse(), "NHC should be enabled")
+				Expect(meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
+				Expect(nhcList.Items[0].Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be enabled")
 
 		})
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -84,15 +84,13 @@ var _ = Describe("e2e", func() {
 		})
 
 		It("should report disabled NHC", func() {
-			Eventually(func() error {
+			Eventually(func(g Gomega) {
 				nhcList := &v1alpha1.NodeHealthCheckList{}
-				Expect(client.List(context.Background(), nhcList)).To(Succeed())
-				if len(nhcList.Items) != 1 {
-					return errors.New("less or more than 1 NHC found")
-				}
-				Expect(meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
-				Expect(nhcList.Items[0].Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
-				return nil
+				g.Expect(client.List(context.Background(), nhcList)).To(Succeed())
+				g.Expect(nhcList.Items).To(HaveLen(1), "less or more than 1 NHC found")
+				nhc := nhcList.Items[0]
+				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
+				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
 			}, 3*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
 		})
 	})
@@ -113,18 +111,14 @@ var _ = Describe("e2e", func() {
 			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "node should not be terminating")
 
 			// ensure NHC is not disabled from previous test
-			Eventually(func() error {
+			Eventually(func(g Gomega) {
 				nhcList := &v1alpha1.NodeHealthCheckList{}
-				if err := client.List(context.Background(), nhcList); err != nil {
-					return err
-				}
-				if len(nhcList.Items) != 1 {
-					return errors.New("less or more than 1 NHC found")
-				}
-				Expect(meta.IsStatusConditionTrue(nhcList.Items[0].Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
-				Expect(nhcList.Items[0].Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
-				return nil
-			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be enabled")
+				g.Expect(client.List(context.Background(), nhcList)).To(Succeed())
+				g.Expect(nhcList.Items).To(HaveLen(1), "less or more than 1 NHC found")
+				nhc := nhcList.Items[0]
+				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
+				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
+			}, 3*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be enabled")
 
 		})
 


### PR DESCRIPTION
In order to give users a quick insight of what NHC is doing at the moment, we introduce 2 new status fields, phase and reson.
Phase will be a one word phase, reason can be a longer statement giving more details about the phase. This is especially useful for UI, so it doesn't have to dtermine a overall status itself.

The phase is determined by looking at
- the Disabled condtion
- the PauseRequests
- InflightRemediations

For easier maintenance of patching the status during reconcilation, the 2nd commit has some refactoring of existing functionality: the status on the resource is set as soon as possible, the actual patch will be done using defer(). This ensures that the status will always be updated when leaving the reconcile function.