### PR TITLE
Remove namespace from CR example

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -8,8 +8,7 @@ metadata:
           "apiVersion": "remediation.medik8s.io/v1alpha1",
           "kind": "NodeHealthCheck",
           "metadata": {
-            "name": "nodehealthcheck-sample",
-            "namespace": "openshift-operators"
+            "name": "nodehealthcheck-sample"
           },
           "spec": {
             "minHealthy": "51%",

--- a/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
+++ b/config/samples/remediation_v1alpha1_nodehealthcheck.yaml
@@ -2,7 +2,6 @@ apiVersion: remediation.medik8s.io/v1alpha1
 kind: NodeHealthCheck
 metadata:
   name: nodehealthcheck-sample
-  namespace: openshift-operators
 spec:
 #  optional
   selector:


### PR DESCRIPTION
It is just wrong (CRD is cluster scoped) and also breaks CR creation in the operatorhub UI (see https://bugzilla.redhat.com/show_bug.cgi?id=2100353)