### PR TITLE
Fix multiple NHC

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -240,6 +240,7 @@ func (r *NodeHealthCheckReconciler) shouldTryRemediation(
 			r.Recorder.Event(nhc, eventTypeNormal, eventReasonRemediationSkipped, msg)
 			return false
 		}
+		// TODO consider doing this check on top of reconcile and set Disabled condition?
 		if r.isClusterUpgrading() {
 			updateResultNextReconcile(result, 1*time.Minute)
 			r.Recorder.Event(nhc, eventTypeNormal, eventReasonRemediationSkipped, "Skipped remediation because the cluster is upgrading")

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -483,13 +483,20 @@ func newRemediationCR(nodeName string) unstructured.Unstructured {
 		Version: TestRemediationCRD.Spec.Versions[0].Name,
 		Kind:    TestRemediationCRD.Spec.Names.Kind,
 	})
+	cr.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: "remediation.medik8s.io/v1alpha1",
+			Kind:       "NodeHealthCheck",
+			Name:       "test",
+		},
+	})
 	return cr
 }
 
 func newRemediationTemplate() runtime.Object {
 	r := map[string]interface{}{
 		"kind":       "InfrastructureRemediation",
-		"apiVersion": "medik8s.io/v1alpha1",
+		"apiVersion": "test.medik8s.io/v1alpha1",
 		"metadata":   map[string]interface{}{},
 		"spec": map[string]interface{}{
 			"size": "foo",
@@ -503,7 +510,7 @@ func newRemediationTemplate() runtime.Object {
 		},
 	}
 	template.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "medik8s.io",
+		Group:   "test.medik8s.io",
 		Version: "v1alpha1",
 		Kind:    "InfrastructureRemediationTemplate",
 	})
@@ -518,7 +525,7 @@ func newNodeHealthCheck() *v1alpha1.NodeHealthCheck {
 	return &v1alpha1.NodeHealthCheck{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NodeHealthCheck",
-			APIVersion: "medik8s.io/v1alpha1",
+			APIVersion: "remediation.medik8s.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
@@ -535,7 +542,7 @@ func newNodeHealthCheck() *v1alpha1.NodeHealthCheck {
 			},
 			RemediationTemplate: &v1.ObjectReference{
 				Kind:       "InfrastructureRemediationTemplate",
-				APIVersion: "medik8s.io/v1alpha1",
+				APIVersion: "test.medik8s.io/v1alpha1",
 				Namespace:  "default",
 				Name:       "template",
 			},
@@ -570,7 +577,6 @@ func newNode(name string, t v1.NodeConditionType, s v1.ConditionStatus, d time.D
 				},
 			},
 		})
-
 }
 
 var TestRemediationCRD = &apiextensions.CustomResourceDefinition{
@@ -582,7 +588,7 @@ var TestRemediationCRD = &apiextensions.CustomResourceDefinition{
 		Name: "infrastructureremediations.medik8s.io",
 	},
 	Spec: apiextensions.CustomResourceDefinitionSpec{
-		Group: "medik8s.io",
+		Group: "test.medik8s.io",
 		Scope: apiextensions.NamespaceScoped,
 		Names: apiextensions.CustomResourceDefinitionNames{
 			Kind:   "InfrastructureRemediation",

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Node Health Check CR", func() {
 				err := reconciler.Client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: cr.GetNamespace(), Name: cr.GetName()}, &cr)
 				Expect(err).NotTo(HaveOccurred())
 
-				cr = newRemediationCR("unhealthy-node-2")
+				cr = newRemediationCR("healthy-node-2")
 				err = reconciler.Client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: cr.GetNamespace(), Name: cr.GetName()}, &cr)
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
@@ -335,12 +335,8 @@ var _ = Describe("Node Health Check CR", func() {
 
 		When("Nodes are candidates for remediation and cluster is upgrading", func() {
 			BeforeEach(func() {
-				objects = newNodes(1, 2)
-				underTest = newNodeHealthCheck()
+				setupObjects(1, 2)
 				upgradeChecker = fakeClusterUpgradeChecker{upgrading: true}
-				remediationTemplate := newRemediationTemplate()
-				remediationCR := newRemediationCR("unhealthy-node-1")
-				objects = append(objects, underTest, remediationTemplate, remediationCR.DeepCopyObject())
 			})
 
 			It("requeues reconciliation to 1 minute from now and updates status", func() {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+
+	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 )
 
 // GetDeploymentNamespace returns the Namespace this operator is deployed on.
@@ -39,4 +43,9 @@ func IsOnOpenshift(config *rest.Config) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// GetLogWithNHC return a logger with NHC namespace and name
+func GetLogWithNHC(log logr.Logger, nhc *v1alpha1.NodeHealthCheck) logr.Logger {
+	return log.WithValues("NodeHealthCheck name", nhc.Name)
 }


### PR DESCRIPTION
When we have multiple NHCs targeting the same nodes, one NHC might consider a node being unhealthy, and another one being healthy, based on different condition config. This leads to a race for creating / deleting the remediation CR. 

This PR solves this by preventing to delete remediation CRs, which are not created (owned) by the NHC currenty being reconciled. Since there also can't be multiple remediation CRs for the same node, this basically means that the 1st NHC which considers a node to be unhealthy wins this race.

This PR is based on https://github.com/medik8s/node-healthcheck-operator/pull/115

Related issues: [ECOPROJECT-908](https://issues.redhat.com//browse/ECOPROJECT-908) [ECOPROJECT-876](https://issues.redhat.com//browse/ECOPROJECT-876)

Todo: confirm correct minHealthy count after this PR, see first issue