### PR TITLE
Add control-plane taint and label for Kubernetes v1.24+

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -260,6 +260,16 @@ spec:
               labels:
                 control-plane: controller-manager
             spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
@@ -303,14 +313,14 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              nodeSelector:
-                node-role.kubernetes.io/master: ""
               priorityClassName: system-cluster-critical
               serviceAccountName: node-healthcheck-operator-controller-manager
               terminationGracePeriodSeconds: 10
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
                 operator: Exists
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,11 +22,21 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
           operator: Exists
       priorityClassName: system-cluster-critical
       containers:


### PR DESCRIPTION
Similar to [NMO's PR](https://github.com/medik8s/node-maintenance-operator/pull/52) we add the new taint and label for `control-plane` node, and in the future we will remove the `master` taint and label.
