### PR TITLE
Use ns != default for test pods

### DIFF
--- a/e2e/utils/boottime.go
+++ b/e2e/utils/boottime.go
@@ -22,11 +22,11 @@ import (
 // This code is for big parts from https://github.com/openshift-kni/performance-addon-operators/tree/master/functests/utils
 
 // GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
-func GetBootTime(c *kubernetes.Clientset, nodeName string, log logr.Logger) (*time.Time, error) {
+func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (*time.Time, error) {
 
 	// create a pod and wait that it's running
 	pod := getBootTimePod(nodeName)
-	pod, err := c.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+	pod, err := c.CoreV1().Pods(ns).Create(context.Background(), pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some admission controllers don't work in default, which causes problems with pod security on OCP 4.12+.
Also use custom ns which allows privileged pods for test pods (api blocker, boot time).