### PR TITLE
Add new test which tests for sorted and grouped imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ IMG ?= $(IMAGE_REGISTRY)/node-healthcheck-operator:$(IMAGE_TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
+# SORT_IMPORTS_VERSION refers to the version of github.com/slintes/sort-imports, used to sort and group imports
+SORT_IMPORTS_VERSION = v0.1.0
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -95,7 +98,7 @@ test: test-no-verify
 	VERSION=0.0.1 $(MAKE) manifests bundle verify
 
 # Generate and format code, and run tests
-test-no-verify: vendor generate fmt vet envtest
+test-no-verify: vendor generate test-imports fmt vet envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/testbin)" go test ./controllers/... ./api/... -coverprofile cover.out -v -ginkgo.v
 
 test-mutation: verify-no-changes fetch-mutation ## Run mutation tests in manual mode.
@@ -143,6 +146,14 @@ fmt: goimports
 # Run go vet against code
 vet:
 	go vet ./...
+
+# Check for sorted imports
+test-imports:
+	go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports .
+
+# Sort imports
+sort-imports:
+	go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports . -w
 
 # Run go mod tidy
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,11 @@ vet:
 
 # Check for sorted imports
 test-imports:
-	go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports .
+	GOFLAGS="" go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports .
 
 # Sort imports
 sort-imports:
-	go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports . -w
+	GOFLAGS="" go install github.com/slintes/sort-imports@${SORT_IMPORTS_VERSION} && sort-imports . -w
 
 # Run go mod tidy
 tidy:

--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -23,9 +23,8 @@ import (
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/controllers/cluster/upgrade_checker.go
+++ b/controllers/cluster/upgrade_checker.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
-
-	v1 "github.com/openshift/api/config/v1"
-
-	clusterversion "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	gerrors "github.com/pkg/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	v1 "github.com/openshift/api/config/v1"
+	clusterversion "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
 )

--- a/controllers/initializer/suite_test.go
+++ b/controllers/initializer/suite_test.go
@@ -24,7 +24,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"go.uber.org/zap/zapcore"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/openshift/api/machine/v1beta1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"

--- a/controllers/mhc/mhc_checker.go
+++ b/controllers/mhc/mhc_checker.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/openshift/api/machine/v1beta1"
+
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/openshift/api/machine/v1beta1"
 )
 
 // NodeConditionTerminating is the node condition type used by the termination handler MHC

--- a/controllers/rbac/suite_test.go
+++ b/controllers/rbac/suite_test.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"go.uber.org/zap/zapcore"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,10 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"go.uber.org/zap/zapcore"
-
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -44,6 +41,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -6,14 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
-
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
-	"github.com/openshift/api/machine/v1beta1"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,6 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 )

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,9 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
-	"github.com/openshift/api/machine/v1beta1"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 	"github.com/medik8s/node-healthcheck-operator/controllers/console"

--- a/main.go
+++ b/main.go
@@ -25,13 +25,13 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/metrics/nodehealthcheck.go
+++ b/metrics/nodehealthcheck.go
@@ -1,22 +1,23 @@
 /*
-   Copyright 2020 The Machine API Operator authors
+Copyright 2020 The Machine API Operator authors
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 


### PR DESCRIPTION
Sort and group imports automatically.

Imports are grouped like:
1. core packages
2. everythings else
3. k8s modules
4. openshift modules
5. own module

Usage:
`make test-imports`: test if the tool would change something
`make sort-imports`: also write changes

The `test-imports` target is also called by the `test` target and will fail the test when changes are detected.
 
See https://github.com/slintes/sort-imports