### PR TITLE
Pod security updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,13 @@ bundle: manifests kustomize operator-sdk
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(MAKE) bundle-fixes bundle-date
 
+# Generate bundle manifests and metadata, then validate generated files.
+.PHONY: bundle-k8s
+bundle-k8s: bundle
+	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
+	$(MAKE) bundle-fixes bundle-date
+
 # Some fixes in the bundle
 DEFAULT_ICON_BASE64 := $(shell base64 --wrap=0 ./config/assets/nhc_blue.png)
 export ICON_BASE64 ?= ${DEFAULT_ICON_BASE64}

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -282,6 +282,11 @@ spec:
                 - containerPort: 8443
                   name: https
                 resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -313,7 +318,12 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
               serviceAccountName: node-healthcheck-operator-controller-manager
               terminationGracePeriodSeconds: 10
               tolerations:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,6 +19,11 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,6 +53,9 @@ spec:
                 fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz
@@ -69,5 +72,7 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manifests-k8s/kustomization.yaml
+++ b/config/manifests-k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../manifests
+
+patchesStrategicMerge:
+  - seccomp_patch.yaml

--- a/config/manifests-k8s/seccomp_patch.yaml
+++ b/config/manifests-k8s/seccomp_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      securityContext:
+        # Do not use SeccompProfile if your project must work on
+        # old k8s versions < 1.19 and OpenShift < 4.11
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
In order to comply with the restricted PSA profile, the pod needs to have
`runAsNonRoot: true`, and all containers need to have
`allowPrivilegeEscalation:false` and drop all caps. Also the Dockerfile should
set a USER.

On k8s we would also need to set seccompProfile.type: RuntimeDefault.
That would break deployment on OCP 4.10 though. So leave it empty by default,
which is fine also on OCP 4.11+.

For community (k8s) releases, there is a new make target `bundle-k8s`,
which adds the seccompProfile to the deployment.

Releated docs:
https://kubernetes.io/docs/concepts/security/pod-security-standards/
https://kubernetes.io/docs/concepts/security/pod-security-admission/
https://master.sdk.operatorframework.io/docs/best-practices/pod-security-standards/

[ECOPROJECT-811](https://issues.redhat.com//browse/ECOPROJECT-811)