### PR TITLE
update CI image versions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -42,13 +42,14 @@ jobs:
         run: |
           # get script from github
           NAME=build-nhc-snr.sh
-          curl https://raw.githubusercontent.com/medik8s/tools/main/scripts/${NAME} -o $NAME
+          curl https://raw.githubusercontent.com/medik8s/tools/main/scripts/${NAME} -o ${NAME}
           chmod +x $NAME
           
           # set version vars
-          export NHC_VERSION=0.3.0-ci
-          export SNR_VERSION=0.4.0-ci
-          export INDEX_VERSION=4.11-ci
+          VERSION=9.9.9-ci
+          export NHC_VERSION=${VERSION}
+          export SNR_VERSION=${VERSION}
+          export INDEX_VERSION=${VERSION}
           
           # build and push images
           ./$NAME --skip-deploy


### PR DESCRIPTION
Use a generic high version number, so we don't need to update for every release, and it can be used for testing updates