### PR TITLE
Update default config selector

### DIFF
--- a/controllers/bootstrap/init_test.go
+++ b/controllers/bootstrap/init_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -15,19 +17,62 @@ import (
 
 var _ = Describe("Init", func() {
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 		Expect(Initialize(context.TODO(), k8sManager, ctrl.Log.WithName("test init"))).To(Succeed())
 	})
 
-	When("initialization is called", func() {
+	AfterEach(func() {
+		// delete default config for next test
+		nhc := &v1alpha1.NodeHealthCheck{}
+		Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: defaults.DefaultCRName}, nhc)).To(Succeed())
+		Expect(k8sClient.Delete(context.Background(), nhc)).To(Succeed())
+	})
+
+	expectUpToDateDefaultConfig := func(nhc *v1alpha1.NodeHealthCheck) {
+		ExpectWithOffset(1, nhc.Name).To(Equal(defaults.DefaultCRName))
+		ExpectWithOffset(1, nhc.Spec.RemediationTemplate).To(Equal(defaults.DefaultTemplateRef))
+		ExpectWithOffset(1, nhc.Spec.Selector).To(Equal(defaults.DefaultSelector))
+	}
+
+	When("initialization is called on 1st install", func() {
 		It("creates a default NHC resource", func() {
 			nhcs := v1alpha1.NodeHealthCheckList{}
-			err := k8sClient.List(context.Background(), &nhcs, &client.ListOptions{
-				Namespace: "",
-			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.List(context.Background(), &nhcs)).To(Succeed())
 			Expect(nhcs.Items).To(HaveLen(1))
-			Expect(nhcs.Items[0].Name).To(Equal(defaults.DefaultCRName))
+			expectUpToDateDefaultConfig(&nhcs.Items[0])
 		})
 	})
+
+	When("initialization is called on upgrade", func() {
+
+		BeforeEach(func() {
+			// create outdated default config
+			outdatedNHC := &v1alpha1.NodeHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaults.DefaultCRName,
+				},
+				Spec: v1alpha1.NodeHealthCheckSpec{
+					Selector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "node-role.kubernetes.io/worker",
+							Operator: metav1.LabelSelectorOpExists,
+						}},
+					},
+					RemediationTemplate: &corev1.ObjectReference{
+						Kind:       "PoisonPillRemediationTemplate",
+						APIVersion: "poison-pill.medik8s.io/v1alpha1",
+						Name:       "poison-pill-default-template",
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), outdatedNHC)).To(Succeed())
+		})
+
+		It("updates the default NHC resource", func() {
+			nhc := &v1alpha1.NodeHealthCheck{}
+			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: defaults.DefaultCRName}, nhc)).To(Succeed())
+			expectUpToDateDefaultConfig(nhc)
+		})
+	})
+
 })

--- a/controllers/utils/node_roles.go
+++ b/controllers/utils/node_roles.go
@@ -1,0 +1,18 @@
+package utils
+
+import v1 "k8s.io/api/core/v1"
+
+const (
+	// WorkerRoleLabel is the role label of worker nodes
+	WorkerRoleLabel = "node-role.kubernetes.io/worker"
+	// MasterRoleLabel is the old role label of control plane nodes
+	MasterRoleLabel = "node-role.kubernetes.io/master"
+	// ControlPlaneRoleLabel is the new role label of control plane nodes
+	ControlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+)
+
+func IsControlPlane(node *v1.Node) bool {
+	_, isControlPlane := node.Labels[MasterRoleLabel]
+	_, isMaster := node.Labels[ControlPlaneRoleLabel]
+	return isControlPlane || isMaster
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,8 +86,10 @@ spec:
   # see k8s doc on selectors https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
   selector:
     matchExpressions:
-      - key: node-role.kubernetes.io/worker
-        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+      - key: node-role.kubernetes.io/master
+        operator: DoesNotExist
   minHealthy: "51%"
   unhealthyConditions:
     - type: Ready


### PR DESCRIPTION
Select !control plane + !master role, instead of selecting worker role,
in order to prevent remediating control plane nodes which also are workers.

[ECOPROJECT-1052](https://issues.redhat.com//browse/ECOPROJECT-1052)
