### PR TITLE
Restrict config updates or deletion during remediations

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,19 +1,21 @@
 domain: medik8s.io
-layout: go.kubebuilder.io/v3
+layout:
+- go.kubebuilder.io/v3
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}
 projectName: node-healthcheck-operator
 repo: github.com/medik8s/node-healthcheck-operator
 resources:
 - api:
     crdVersion: v1
-  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
   controller: true
   domain: medik8s.io
   group: remediation
   kind: NodeHealthCheck
-  # TODO(user): Update the package path for your API if the below value is incorrect.
   path: github.com/medik8s/node-healthcheck-operator/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"
-plugins:
-  manifests.sdk.operatorframework.io/v2: {}
-  scorecard.sdk.operatorframework.io/v2: {}

--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -31,6 +31,8 @@ const (
 	WebhookCertDir  = "/apiserver.local.config/certificates"
 	WebhookCertName = "apiserver.crt"
 	WebhookKeyName  = "apiserver.key"
+
+	OngoingRemediationError = "prohibited due to running remediation"
 )
 
 // log is for logging in this package.
@@ -75,7 +77,7 @@ func (r *NodeHealthCheck) ValidateCreate() error {
 func (r *NodeHealthCheck) ValidateUpdate(old runtime.Object) error {
 	nodehealthchecklog.Info("validate update", "name", r.Name)
 	if r.isRemediating() {
-		return fmt.Errorf("update prohibited due to running remediations")
+		return fmt.Errorf("update %s", OngoingRemediationError)
 	}
 	return nil
 }
@@ -84,7 +86,7 @@ func (r *NodeHealthCheck) ValidateUpdate(old runtime.Object) error {
 func (r *NodeHealthCheck) ValidateDelete() error {
 	nodehealthchecklog.Info("validate delete", "name", r.Name)
 	if r.isRemediating() {
-		return fmt.Errorf("deletion prohibited due to running remediations")
+		return fmt.Errorf("deletion %s", OngoingRemediationError)
 	}
 	return nil
 }

--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -17,48 +17,78 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	WebhookCertDir  = "/apiserver.local.config/certificates"
+	WebhookCertName = "apiserver.crt"
+	WebhookKeyName  = "apiserver.key"
+)
+
 // log is for logging in this package.
 var nodehealthchecklog = logf.Log.WithName("nodehealthcheck-resource")
 
 func (r *NodeHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
+
+	// check if OLM injected certs
+	certs := []string{filepath.Join(WebhookCertDir, WebhookCertName), filepath.Join(WebhookCertDir, WebhookKeyName)}
+	certsInjected := true
+	for _, fname := range certs {
+		if _, err := os.Stat(fname); err != nil {
+			certsInjected = false
+			break
+		}
+	}
+	if certsInjected {
+		server := mgr.GetWebhookServer()
+		server.CertDir = WebhookCertDir
+		server.CertName = WebhookCertName
+		server.KeyName = WebhookKeyName
+	} else {
+		nodehealthchecklog.Info("OLM injected certs for webhooks not found")
+	}
+
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-remediation-medik8s-io-v1alpha1-nodehealthcheck,mutating=false,failurePolicy=fail,sideEffects=None,groups=remediation.medik8s.io,resources=nodehealthchecks,verbs=create;update,versions=v1alpha1,name=vnodehealthcheck.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-remediation-medik8s-io-v1alpha1-nodehealthcheck,mutating=false,failurePolicy=fail,sideEffects=None,groups=remediation.medik8s.io,resources=nodehealthchecks,verbs=update;delete,versions=v1alpha1,name=vnodehealthcheck.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &NodeHealthCheck{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *NodeHealthCheck) ValidateCreate() error {
 	nodehealthchecklog.Info("validate create", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object creation.
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *NodeHealthCheck) ValidateUpdate(old runtime.Object) error {
 	nodehealthchecklog.Info("validate update", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object update.
+	if r.isRemediating() {
+		return fmt.Errorf("update prohibited due to running remediations")
+	}
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *NodeHealthCheck) ValidateDelete() error {
 	nodehealthchecklog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
+	if r.isRemediating() {
+		return fmt.Errorf("deletion prohibited due to running remediations")
+	}
 	return nil
+}
+
+func (r *NodeHealthCheck) isRemediating() bool {
+	return len(r.Status.InFlightRemediations) > 0
 }

--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var nodehealthchecklog = logf.Log.WithName("nodehealthcheck-resource")
+
+func (r *NodeHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-remediation-medik8s-io-v1alpha1-nodehealthcheck,mutating=false,failurePolicy=fail,sideEffects=None,groups=remediation.medik8s.io,resources=nodehealthchecks,verbs=create;update,versions=v1alpha1,name=vnodehealthcheck.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &NodeHealthCheck{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *NodeHealthCheck) ValidateCreate() error {
+	nodehealthchecklog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *NodeHealthCheck) ValidateUpdate(old runtime.Object) error {
+	nodehealthchecklog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *NodeHealthCheck) ValidateDelete() error {
+	nodehealthchecklog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	//+kubebuilder:scaffold:imports
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Webhook Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+		},
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&NodeHealthCheck{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,9 +22,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/bundle/manifests/node-healthcheck-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/node-healthcheck-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: node-healthcheck-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -460,3 +460,24 @@ spec:
     name: medik8s
     url: https://github.com/medik8s
   version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: node-healthcheck-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vnodehealthcheck.kb.io
+    rules:
+    - apiGroups:
+      - remediation.medik8s.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - UPDATE
+      - DELETE
+      resources:
+      - nodehealthchecks
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-remediation-medik8s-io-v1alpha1-nodehealthcheck

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ bases:
 - ../console-plugin
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-remediation-medik8s-io-v1alpha1-nodehealthcheck
+  failurePolicy: Fail
+  name: vnodehealthcheck.kb.io
+  rules:
+  - apiGroups:
+    - remediation.medik8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - nodehealthchecks
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/main.go
+++ b/main.go
@@ -23,11 +23,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/medik8s/node-healthcheck-operator/controllers/bootstrap"
-
-	"github.com/medik8s/node-healthcheck-operator/controllers"
-	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
-	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
 	"go.uber.org/zap/zapcore"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -46,6 +41,10 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	"github.com/medik8s/node-healthcheck-operator/controllers"
+	"github.com/medik8s/node-healthcheck-operator/controllers/bootstrap"
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
+	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
 	"github.com/medik8s/node-healthcheck-operator/metrics"
 	"github.com/medik8s/node-healthcheck-operator/version"
 	// +kubebuilder:scaffold:imports
@@ -144,6 +143,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&remediationv1alpha1.NodeHealthCheck{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NodeHealthCheck")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	ctx := ctrl.SetupSignalHandler()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -641,6 +641,7 @@ sigs.k8s.io/controller-runtime/pkg/controller
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/conversion
 sigs.k8s.io/controller-runtime/pkg/envtest
+sigs.k8s.io/controller-runtime/pkg/envtest/printer
 sigs.k8s.io/controller-runtime/pkg/event
 sigs.k8s.io/controller-runtime/pkg/handler
 sigs.k8s.io/controller-runtime/pkg/healthz

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/printer/ginkgo.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/printer/ginkgo.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package printer contains setup for a friendlier Ginkgo printer that's easier
+// to parse by test automation.
+package printer
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+var _ ginkgo.Reporter = NewlineReporter{}
+
+// NewlineReporter is Reporter that Prints a newline after the default Reporter output so that the results
+// are correctly parsed by test automation.
+// See issue https://github.com/jstemmer/go-junit-report/issues/31
+type NewlineReporter struct{}
+
+// SpecSuiteWillBegin implements ginkgo.Reporter.
+func (NewlineReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+}
+
+// BeforeSuiteDidRun implements ginkgo.Reporter.
+func (NewlineReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+// AfterSuiteDidRun implements ginkgo.Reporter.
+func (NewlineReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+// SpecWillRun implements ginkgo.Reporter.
+func (NewlineReporter) SpecWillRun(specSummary *types.SpecSummary) {}
+
+// SpecDidComplete implements ginkgo.Reporter.
+func (NewlineReporter) SpecDidComplete(specSummary *types.SpecSummary) {}
+
+// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:".
+func (NewlineReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) { fmt.Printf("\n") }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/printer/prow.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/printer/prow.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/ginkgo/types"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	allRegisteredSuites     = sets.String{}
+	allRegisteredSuitesLock = &sync.Mutex{}
+)
+
+type prowReporter struct {
+	junitReporter *reporters.JUnitReporter
+}
+
+// NewProwReporter returns a prowReporter that will write out junit if running in Prow and do
+// nothing otherwise.
+// WARNING: It seems this does not always properly fail the test runs when there are failures,
+// see https://github.com/onsi/ginkgo/issues/706
+// When using this you must make sure to grep for failures in your junit xmls and fail the run
+// if there are any.
+func NewProwReporter(suiteName string) ginkgo.Reporter {
+	allRegisteredSuitesLock.Lock()
+	if allRegisteredSuites.Has(suiteName) {
+		panic(fmt.Sprintf("Suite named %q registered more than once", suiteName))
+	}
+	allRegisteredSuites.Insert(suiteName)
+	allRegisteredSuitesLock.Unlock()
+
+	if os.Getenv("CI") == "" {
+		return &prowReporter{}
+	}
+	artifactsDir := os.Getenv("ARTIFACTS")
+	if artifactsDir == "" {
+		return &prowReporter{}
+	}
+
+	path := filepath.Join(artifactsDir, fmt.Sprintf("junit_%s_%d.xml", suiteName, config.GinkgoConfig.ParallelNode))
+	return &prowReporter{
+		junitReporter: reporters.NewJUnitReporter(path),
+	}
+}
+
+func (pr *prowReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.SpecSuiteWillBegin(config, summary)
+	}
+}
+
+// BeforeSuiteDidRun implements ginkgo.Reporter.
+func (pr *prowReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.BeforeSuiteDidRun(setupSummary)
+	}
+}
+
+// AfterSuiteDidRun implements ginkgo.Reporter.
+func (pr *prowReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.AfterSuiteDidRun(setupSummary)
+	}
+}
+
+// SpecWillRun implements ginkgo.Reporter.
+func (pr *prowReporter) SpecWillRun(specSummary *types.SpecSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.SpecWillRun(specSummary)
+	}
+}
+
+// SpecDidComplete implements ginkgo.Reporter.
+func (pr *prowReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.SpecDidComplete(specSummary)
+	}
+}
+
+// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:".
+func (pr *prowReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	if pr.junitReporter != nil {
+		pr.junitReporter.SpecSuiteDidEnd(summary)
+	}
+}


### PR DESCRIPTION
Add a validating webhook which prevents
- updates of the node selector
- deletions of NHC resources

while they have ongoing remediation, in order to prevent dangling remediations.

[ECOPROJECT-1060](https://issues.redhat.com//browse/ECOPROJECT-1060)