### PR TITLE
Fix empty status fields when they are 0

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -122,15 +122,18 @@ type UnhealthyCondition struct {
 // NodeHealthCheckStatus defines the observed state of NodeHealthCheck
 type NodeHealthCheckStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="observedNodes",xDescriptors="urn:alm:descriptor:com.tectonic.ui:observedNodes"
-	//ObservedNodes specified the number of nodes observed by using the NHC spec.selecor
-	ObservedNodes int `json:"observedNodes,omitempty"`
+	//ObservedNodes specified the number of nodes observed by using the NHC spec.selector
+	// +kubebuilder:default:=0
+	ObservedNodes int `json:"observedNodes"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="healthynodes",xDescriptors="urn:alm:descriptor:com.tectonic.ui:healthyNodes"
 	//HealthyNodes specified the number of healthy nodes observed
-	HealthyNodes int `json:"healthyNodes,omitempty"`
+	// +kubebuilder:default:=0
+	HealthyNodes int `json:"healthyNodes"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="inFlightRemediations",xDescriptors="urn:alm:descriptor:com.tectonic.ui:inFlightRemediations"
 	//InFlightRemediations records the timestamp when remediation triggered per node
+	//+optional
 	InFlightRemediations map[string]metav1.Time `json:"inFlightRemediations,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="conditions",xDescriptors="urn:alm:descriptor:com.tectonic.ui:conditions"

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -112,7 +112,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:inFlightRemediations
       - description: ObservedNodes specified the number of nodes observed by using
-          the NHC spec.selecor
+          the NHC spec.selector
         displayName: observedNodes
         path: observedNodes
         x-descriptors:

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -260,6 +260,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               healthyNodes:
+                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -270,8 +271,9 @@ spec:
                   triggered per node
                 type: object
               observedNodes:
+                default: 0
                 description: ObservedNodes specified the number of nodes observed
-                  by using the NHC spec.selecor
+                  by using the NHC spec.selector
                 type: integer
               phase:
                 description: Phase represents the current phase of this Config. Known
@@ -282,6 +284,9 @@ spec:
               reason:
                 description: Reason explains the current phase in more detail.
                 type: string
+            required:
+            - healthyNodes
+            - observedNodes
             type: object
         type: object
     served: true

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -261,6 +261,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               healthyNodes:
+                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -271,8 +272,9 @@ spec:
                   triggered per node
                 type: object
               observedNodes:
+                default: 0
                 description: ObservedNodes specified the number of nodes observed
-                  by using the NHC spec.selecor
+                  by using the NHC spec.selector
                 type: integer
               phase:
                 description: Phase represents the current phase of this Config. Known
@@ -283,6 +285,9 @@ spec:
               reason:
                 description: Reason explains the current phase in more detail.
                 type: string
+            required:
+            - healthyNodes
+            - observedNodes
             type: object
         type: object
     served: true

--- a/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:inFlightRemediations
       - description: ObservedNodes specified the number of nodes observed by using
-          the NHC spec.selecor
+          the NHC spec.selector
         displayName: observedNodes
         path: observedNodes
         x-descriptors:


### PR DESCRIPTION
- make those fields required
- set their default value to 0

This way their value is always returned, and patching with zero values works

[ECOPROJECT-1071](https://issues.redhat.com//browse/ECOPROJECT-1071)