### PR TITLE
Fix e2e test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,8 +43,9 @@ var _ = Describe("e2e", func() {
 			// find a worker node
 			workers := &v1.NodeList{}
 			selector := labels.NewSelector()
-			req, _ := labels.NewRequirement("node-role.kubernetes.io/control-plane", selection.DoesNotExist, []string{})
-			selector = selector.Add(*req)
+			reqCpRole, _ := labels.NewRequirement("node-role.kubernetes.io/control-plane", selection.DoesNotExist, []string{})
+			reqMRole, _ := labels.NewRequirement("node-role.kubernetes.io/master", selection.DoesNotExist, []string{})
+			selector = selector.Add(*reqCpRole, *reqMRole)
 			Expect(k8sClient.List(context.Background(), workers, &ctrl.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
 			Expect(len(workers.Items)).To(BeNumerically(">=", 2))
 			nodeUnderTest = &workers.Items[0]


### PR DESCRIPTION
OCP 4.11 does not use control plane role label yet

