### PR TITLE
Prevent template update during remediations

### DIFF
--- a/api/v1alpha1/nodehealthcheck_webhook_test.go
+++ b/api/v1alpha1/nodehealthcheck_webhook_test.go
@@ -4,13 +4,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ = Describe("NodeHealthCheck Validation", func() {
 
-	Context("a NHC", func() {
+	Context("Creating or updating a NHC", func() {
 
 		var nhc *NodeHealthCheck
 
@@ -71,4 +72,67 @@ var _ = Describe("NodeHealthCheck Validation", func() {
 		})
 	})
 
+	Context("During ongoing remediation", func() {
+
+		var nhcOld *NodeHealthCheck
+		var nhcNew *NodeHealthCheck
+
+		BeforeEach(func() {
+			mh := intstr.FromString("51%")
+			nhcOld = &NodeHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: NodeHealthCheckSpec{
+					MinHealthy: &mh,
+					Selector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "node-role.kubernetes.io/control-plane",
+								Operator: metav1.LabelSelectorOpDoesNotExist,
+							},
+						},
+					},
+					RemediationTemplate: &v1.ObjectReference{
+						Name: "OldName",
+					},
+				},
+				Status: NodeHealthCheckStatus{
+					InFlightRemediations: map[string]metav1.Time{
+						"test": metav1.Now(),
+					},
+				},
+			}
+		})
+
+		Context("updating selector", func() {
+			BeforeEach(func() {
+				nhcNew = nhcOld.DeepCopy()
+				nhcNew.Spec.Selector.MatchExpressions[0].Key = "node-role.kubernetes.io/infra"
+			})
+			It("should be denied", func() {
+				Expect(nhcNew.ValidateUpdate(nhcOld)).To(MatchError(
+					And(
+						ContainSubstring(OngoingRemediationError),
+						ContainSubstring("selector"),
+					),
+				))
+			})
+		})
+
+		Context("updating template", func() {
+			BeforeEach(func() {
+				nhcNew = nhcOld.DeepCopy()
+				nhcNew.Spec.RemediationTemplate.Name = "newName"
+			})
+			It("should be denied", func() {
+				Expect(nhcNew.ValidateUpdate(nhcOld)).To(MatchError(
+					And(
+						ContainSubstring(OngoingRemediationError),
+						ContainSubstring("remediation template"),
+					),
+				))
+			})
+		})
+	})
 })

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to


### PR DESCRIPTION
Updating the template during remediations can result in dangling remediations.

[ECOPROJECT-1122](https://issues.redhat.com//browse/ECOPROJECT-1122)