### PR TITLE
Add note to description in CSV about PSA for SNR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,10 +270,11 @@ bundle-k8s: bundle
 	sed -r -i "/displayName: Node Health Check Operator/ i\    " ${CSV}
 	sed -r -i "/displayName: Node Health Check Operator/ i\    ### Notes" ${CSV}
 	sed -r -i "/displayName: Node Health Check Operator/ i\    In case Pod Security Admission is used, please allow Pods to run" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    in the \"privileged\" Pod Security Standard policy by e.g. labeling the" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    the target namespace accordingly before installing NHC, because the dependent" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    Self Node Remediation operator needs it for rebooting unhealthy nodes." ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    in the \"privileged\" Pod Security Standard policy." ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    This is required by the dependent Self Node Remediation operator" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    for rebooting unhealthy nodes, and can be done by labeling the" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    the target namespace accordingly before installing NHC." ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/ ." ${CSV}
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Apply version or build date related changes in the bundle

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ENVTEST_VERSION = v0.0.0-20230208013708-22718275bffe # no tagged versions :/
 GOIMPORTS_VERSION = v0.5.0
 SORT_IMPORTS_VERSION = v0.1.0
 
-# VERSION defines the project version for the bundle. 
+# VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
@@ -260,10 +260,20 @@ bundle: manifests kustomize operator-sdk
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
+export CSV="./bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml"
+
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle-k8s
 bundle-k8s: bundle
 	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+
+	sed -r -i "/displayName: Node Health Check Operator/ i\    " ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    ### Notes" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    In case Pod Security Admission is used, please allow Pods to run" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    in the \"privileged\" Pod Security Standard policy by e.g. labeling the" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    the target namespace accordingly before installing NHC, because the dependent" ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    Self Node Remediation operator needs it for rebooting unhealthy nodes." ${CSV}
+	sed -r -i "/displayName: Node Health Check Operator/ i\    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/" ${CSV}
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Apply version or build date related changes in the bundle
@@ -272,11 +282,11 @@ export ICON_BASE64 ?= ${DEFAULT_ICON_BASE64}
 .PHONY: bundle-update
 bundle-update:
     # update container image in the metadata
-	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ${CSV}
 	# set skipRange
-	sed -r -i "s|olm.skipRange: .*|olm.skipRange: '>=0.1.0 <${VERSION}'|;" ./bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+	sed -r -i "s|olm.skipRange: .*|olm.skipRange: '>=0.1.0 <${VERSION}'|;" ${CSV}
 	# set icon (not version or build date related, but just to not having this huge data permanently in the CSV)
-	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ./bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ${CSV}
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Revert all version or build date related changes


### PR DESCRIPTION
Result will look like this:

```
    In the case of transient errors, the watchdog’s actions will also result in
    the node rebooting and rejoining the cluster - restoring capacity.
    
    ### Notes
    In case Pod Security Admission is used, please allow Pods to run
    in the "privileged" Pod Security Standard policy by e.g. labeling the
    the target namespace accordingly before installing NHC, because the dependent
    Self Node Remediation operator needs it for rebooting unhealthy nodes.
    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/
  displayName: Node Health Check Operator
  icon:
```