### PR TITLE
Add node's machine as owner to remediation CR

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -30,6 +30,8 @@ const (
 	ConditionReasonDisabledMHC = "ConflictingMachineHealthCheckDetected"
 	// ConditionReasonDisabledTemplateNotFound is the reason for type Disabled when the template wasn't found
 	ConditionReasonDisabledTemplateNotFound = "RemediationTemplateNotFound"
+	// ConditionReasonDisabledTemplateWrongNamespace is the reason for type Disabled when the template is in the wrong namespace
+	ConditionReasonDisabledTemplateWrongNamespace = "RemediationTemplateWrongNamespace"
 	// ConditionReasonEnabled is the condition reason for type Disabled and status False
 	ConditionReasonEnabled = "NodeHealthCheckEnabled"
 )


### PR DESCRIPTION
Some remediators (e.g. Metal3) need the unhealthy machine and not just node, because they delete the node during remediation. Add the machine as owner ref to the remediation CR, if applciable.

For now only Openshift's Machine API's Machines are supported.
Cluster API's Machines are on the TODO list.

[ECOPROJECT-1045](https://issues.redhat.com//browse/ECOPROJECT-1045)