### PR TITLE
Add empty selector validation

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -56,7 +56,12 @@ const (
 // NodeHealthCheckSpec defines the desired state of NodeHealthCheck
 type NodeHealthCheckSpec struct {
 	// Label selector to match nodes whose health will be exercised.
-	// Note: An empty selector will match all nodes.
+	//
+	// Selecting both control-plane and worker nodes in one NHC CR is
+	// highly discouraged and can result in undesired behaviour.
+	//
+	// Note: mandatory now for above reason, but for backwards compatibility existing
+	// CRs will continue to work with an empty selector, which matches all nodes.
 	//
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -40,6 +40,7 @@ const (
 	OngoingRemediationError   = "prohibited due to running remediation"
 	minHealthyError           = "MinHealthy must not be negative"
 	invalidSelectorError      = "Invalid selector"
+	missingSelectorError      = "Selector is mandatory"
 	mandatoryRemediationError = "Either RemediationTemplate or at least one EscalatingRemediations must be set"
 	mutualRemediationError    = "RemediationTemplate and EscalatingRemediations usage is mutual exclusive"
 	uniqueOrderError          = "EscalatingRemediation Order must be unique"
@@ -137,6 +138,9 @@ func (nhc *NodeHealthCheck) validateMinHealthy() error {
 }
 
 func (nhc *NodeHealthCheck) validateSelector() error {
+	if len(nhc.Spec.Selector.MatchExpressions) == 0 && len(nhc.Spec.Selector.MatchLabels) == 0 {
+		return fmt.Errorf(missingSelectorError)
+	}
 	if _, err := metav1.LabelSelectorAsSelector(&nhc.Spec.Selector); err != nil {
 		return fmt.Errorf("%s: %v", invalidSelectorError, err.Error())
 	}

--- a/api/v1alpha1/nodehealthcheck_webhook_test.go
+++ b/api/v1alpha1/nodehealthcheck_webhook_test.go
@@ -89,6 +89,17 @@ var _ = Describe("NodeHealthCheck Validation", func() {
 			})
 		})
 
+		Context("with empty selector", func() {
+			BeforeEach(func() {
+				selector := metav1.LabelSelector{}
+				nhc.Spec.Selector = selector
+			})
+
+			It("should be denied", func() {
+				Expect(nhc.validate()).To(MatchError(ContainSubstring(missingSelectorError)))
+			})
+		})
+
 		Context("with neither remediation template or escalating remediations set", func() {
 			BeforeEach(func() {
 				nhc.Spec.RemediationTemplate = nil

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -110,8 +110,11 @@ spec:
           picked up by a remediation provider. \n Mutually exclusive with EscalatingRemediations"
         displayName: Remediation Template
         path: remediationTemplate
-      - description: 'Label selector to match nodes whose health will be exercised.
-          Note: An empty selector will match all nodes.'
+      - description: "Label selector to match nodes whose health will be exercised.
+          \n Selecting both control-plane and worker nodes in one NHC CR is highly
+          discouraged and can result in undesired behaviour. \n Note: mandatory now
+          for above reason, but for backwards compatibility existing CRs will continue
+          to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
       - description: UnhealthyConditions contains a list of the conditions that determine

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -175,8 +175,12 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               selector:
-                description: 'Label selector to match nodes whose health will be exercised.
-                  Note: An empty selector will match all nodes.'
+                description: "Label selector to match nodes whose health will be exercised.
+                  \n Selecting both control-plane and worker nodes in one NHC CR is
+                  highly discouraged and can result in undesired behaviour. \n Note:
+                  mandatory now for above reason, but for backwards compatibility
+                  existing CRs will continue to work with an empty selector, which
+                  matches all nodes."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -174,8 +174,12 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               selector:
-                description: 'Label selector to match nodes whose health will be exercised.
-                  Note: An empty selector will match all nodes.'
+                description: "Label selector to match nodes whose health will be exercised.
+                  \n Selecting both control-plane and worker nodes in one NHC CR is
+                  highly discouraged and can result in undesired behaviour. \n Note:
+                  mandatory now for above reason, but for backwards compatibility
+                  existing CRs will continue to work with an empty selector, which
+                  matches all nodes."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -70,8 +70,11 @@ spec:
           picked up by a remediation provider. \n Mutually exclusive with EscalatingRemediations"
         displayName: Remediation Template
         path: remediationTemplate
-      - description: 'Label selector to match nodes whose health will be exercised.
-          Note: An empty selector will match all nodes.'
+      - description: "Label selector to match nodes whose health will be exercised.
+          \n Selecting both control-plane and worker nodes in one NHC CR is highly
+          discouraged and can result in undesired behaviour. \n Note: mandatory now
+          for above reason, but for backwards compatibility existing CRs will continue
+          to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
       - description: UnhealthyConditions contains a list of the conditions that determine


### PR DESCRIPTION
We allow control plane fencing now, but strongly discourage using the same NHC config for control plane and worker nodes. On the other hand we allow the node selector to be empty, which results in selecting ALL nodes. That does not make sense. So disallow empty selectors.

For backwards compatibilty, we will still process existing NHCs with empty selectors

[ECOPROJECT-1220](https://issues.redhat.com//browse/ECOPROJECT-1220)