### PR TITLE
Handle "Processing" condition

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -98,7 +98,8 @@ type NodeHealthCheckSpec struct {
 
 	// EscalatingRemediations contain a list of ordered remediation templates with a timeout.
 	// The remediation templates will be used one after another, until the unhealthy node
-	// gets healthy within the timeout of the currently processed remediation.
+	// gets healthy within the timeout of the currently processed remediation. The order of
+	// remediation is defined by the "order" field of each "escalatingRemediation".
 	//
 	// Mutually exclusive with RemediationTemplate
 	//

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -70,7 +70,9 @@ spec:
       - description: "EscalatingRemediations contain a list of ordered remediation
           templates with a timeout. The remediation templates will be used one after
           another, until the unhealthy node gets healthy within the timeout of the
-          currently processed remediation. \n Mutually exclusive with RemediationTemplate"
+          currently processed remediation. The order of remediation is defined by
+          the \"order\" field of each \"escalatingRemediation\". \n Mutually exclusive
+          with RemediationTemplate"
         displayName: Escalating Remediations
         path: escalatingRemediations
       - description: Order defines the order for this remediation. Remediations with

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -42,8 +42,9 @@ spec:
                 description: "EscalatingRemediations contain a list of ordered remediation
                   templates with a timeout. The remediation templates will be used
                   one after another, until the unhealthy node gets healthy within
-                  the timeout of the currently processed remediation. \n Mutually
-                  exclusive with RemediationTemplate"
+                  the timeout of the currently processed remediation. The order of
+                  remediation is defined by the \"order\" field of each \"escalatingRemediation\".
+                  \n Mutually exclusive with RemediationTemplate"
                 items:
                   description: EscalatingRemediation defines a remediation template
                     with order and timeout

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -41,8 +41,9 @@ spec:
                 description: "EscalatingRemediations contain a list of ordered remediation
                   templates with a timeout. The remediation templates will be used
                   one after another, until the unhealthy node gets healthy within
-                  the timeout of the currently processed remediation. \n Mutually
-                  exclusive with RemediationTemplate"
+                  the timeout of the currently processed remediation. The order of
+                  remediation is defined by the \"order\" field of each \"escalatingRemediation\".
+                  \n Mutually exclusive with RemediationTemplate"
                 items:
                   description: EscalatingRemediation defines a remediation template
                     with order and timeout

--- a/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -30,7 +30,9 @@ spec:
       - description: "EscalatingRemediations contain a list of ordered remediation
           templates with a timeout. The remediation templates will be used one after
           another, until the unhealthy node gets healthy within the timeout of the
-          currently processed remediation. \n Mutually exclusive with RemediationTemplate"
+          currently processed remediation. The order of remediation is defined by
+          the \"order\" field of each \"escalatingRemediation\". \n Mutually exclusive
+          with RemediationTemplate"
         displayName: Escalating Remediations
         path: escalatingRemediations
       - description: Order defines the order for this remediation. Remediations with

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -67,6 +67,7 @@ const (
 	eventTypeNormal                  = "Normal"
 	eventTypeWarning                 = "Warning"
 	enabledMessage                   = "No issues found, NodeHealthCheck is enabled."
+	conditionTypeProcessing          = "Processing"
 
 	// RemediationControlPlaneLabelKey is the label key to put on remediation CRs for control plane nodes
 	RemediationControlPlaneLabelKey = "remediation.medik8s.io/isControlPlaneNode"
@@ -607,7 +608,7 @@ func getProcessingCondition(u *unstructured.Unstructured, log logr.Logger) *meta
 	if conditions, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions"); found {
 		for _, condition := range conditions {
 			if condition, ok := condition.(map[string]interface{}); ok {
-				if condType, found, _ := unstructured.NestedString(condition, "type"); found && condType == "Processing" {
+				if condType, found, _ := unstructured.NestedString(condition, "type"); found && condType == conditionTypeProcessing {
 					condStatus, _, _ := unstructured.NestedString(condition, "status")
 					var condLastTransition time.Time
 					if condLastTransitionString, foundLastTransition, _ := unstructured.NestedString(condition, "lastTransitionTime"); foundLastTransition {

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -87,6 +88,7 @@ type NodeHealthCheckReconciler struct {
 	OnOpenShift                 bool
 	ctrl                        controller.Controller
 	watches                     map[string]struct{}
+	watchesLock                 sync.Mutex
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -557,6 +559,9 @@ func updateResultNextReconcile(result *ctrl.Result, updatedRequeueAfter time.Dur
 }
 
 func (r *NodeHealthCheckReconciler) addWatch(remediationCR *unstructured.Unstructured) error {
+	r.watchesLock.Lock()
+	defer r.watchesLock.Unlock()
+
 	key := remediationCR.GroupVersionKind().String()
 	if _, exists := r.watches[key]; exists {
 		// already watching

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -251,6 +251,11 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// we are done in case we don't have unhealthy nodes
+	if len(unhealthyNodes) == 0 {
+		return result, nil
+	}
+
 	// check if we have enough healthy nodes
 	if minHealthy, err := intstr.GetScaledValueFromIntOrPercent(nhc.Spec.MinHealthy, len(nodes), true); err != nil {
 		log.Error(err, "failed to calculate min healthy allowed nodes",

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -418,7 +418,7 @@ func (r *NodeHealthCheckReconciler) remediate(node *v1.Node, nhc *remediationv1a
 		return pointer.Duration(1 * time.Second), nil
 	}
 
-	now := metav1.Now()
+	now := metav1.Time{Time: currentTime()}
 	timeoutAt := startedRemediation.Started.Add(*timeout)
 	if !now.After(timeoutAt) {
 		// not timed out yet, come back when we do so
@@ -432,7 +432,7 @@ func (r *NodeHealthCheckReconciler) remediate(node *v1.Node, nhc *remediationv1a
 	if annotations == nil {
 		annotations = make(map[string]string, 1)
 	}
-	annotations[remediationTimedOutAnnotationkey] = metav1.Now().Format(time.RFC3339)
+	annotations[remediationTimedOutAnnotationkey] = now.Format(time.RFC3339)
 	remediationCR.SetAnnotations(annotations)
 	if rm.UpdateRemediationCR(remediationCR); err != nil {
 		return nil, errors.Wrapf(err, "failed to update remediation CR with timeout annotation")

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -569,7 +569,7 @@ func (r *NodeHealthCheckReconciler) addWatch(remediationCR *unstructured.Unstruc
 	}
 	if err := r.ctrl.Watch(
 		&source.Kind{Type: remediationCR},
-		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationCRMapperFunc(r.Client, r.Log)),
+		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationCRMapperFunc(r.Log)),
 		predicate.Funcs{
 			// we are just interested in update events for now
 			CreateFunc:  func(_ event.CreateEvent) bool { return false },

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -545,6 +545,54 @@ var _ = Describe("Node Health Check CR", func() {
 			})
 		})
 
+		Context("with progressing condition being set", func() {
+
+			BeforeEach(func() {
+				templateRef1 := underTest.Spec.RemediationTemplate
+				underTest.Spec.RemediationTemplate = nil
+				underTest.Spec.EscalatingRemediations = []v1alpha1.EscalatingRemediation{
+					{
+						RemediationTemplate: *templateRef1,
+						Order:               0,
+						Timeout:             metav1.Duration{Duration: 5 * time.Minute},
+					},
+				}
+				setupObjects(1, 2)
+			})
+
+			It("it should timeout early", func() {
+				cr := newRemediationCR("unhealthy-worker-node-1", underTest)
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+
+				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations[0].Started).ToNot(BeNil())
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations[0].TimedOut).To(BeNil())
+
+				By("letting the remediation stop progressing")
+				conditions := []interface{}{
+					map[string]interface{}{
+						"type":               "Progressing",
+						"status":             "False",
+						"lastTransitionTime": time.Now().Format(time.RFC3339),
+					},
+				}
+				unstructured.SetNestedSlice(cr.Object, conditions, "status", "conditions")
+				Expect(k8sClient.Status().Update(context.Background(), cr))
+
+				// Wait for hardcoded timeout to expire
+				time.Sleep(remediationNotProgressingTimeout + 5*time.Second)
+
+				// get updated CR
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+				Expect(cr.GetAnnotations()).To(HaveKeyWithValue(Equal("remediation.medik8s.io/nhc-timed-out"), Not(BeNil())))
+
+				// get updated NHC
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations[0].TimedOut).ToNot(BeNil())
+				Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
+			})
+		})
+
 		Context("control plane nodes", func() {
 			When("two control plane nodes are unhealthy, just one should be remediated", func() {
 				BeforeEach(func() {

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -571,7 +571,7 @@ var _ = Describe("Node Health Check CR", func() {
 				By("letting the remediation stop progressing")
 				conditions := []interface{}{
 					map[string]interface{}{
-						"type":               "Progressing",
+						"type":               "Processing",
 						"status":             "False",
 						"lastTransitionTime": time.Now().Format(time.RFC3339),
 					},
@@ -580,7 +580,7 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(k8sClient.Status().Update(context.Background(), cr))
 
 				// Wait for hardcoded timeout to expire
-				time.Sleep(remediationNotProgressingTimeout + 5*time.Second)
+				time.Sleep(remediationNotProcessingTimeout + 5*time.Second)
 
 				// get updated CR
 				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)).To(Succeed())

--- a/controllers/utils/mapper.go
+++ b/controllers/utils/mapper.go
@@ -57,7 +57,7 @@ func NHCByNodeMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
 }
 
 // NHCByRemediationCRMapperFunc return the RemediationCR-to-NHC mapper function
-func NHCByRemediationCRMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
+func NHCByRemediationCRMapperFunc(logger logr.Logger) handler.MapFunc {
 	// This closure is meant to get the NHC for the given remediation CR
 	delegate := func(o client.Object) []reconcile.Request {
 		requests := make([]reconcile.Request, 0)

--- a/controllers/utils/mapper.go
+++ b/controllers/utils/mapper.go
@@ -29,21 +29,21 @@ func NHCByNodeMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
 		node := &v1.Node{}
 		if err := c.Get(context.Background(), client.ObjectKey{Name: o.GetName()}, node); err != nil {
 			if !errors.IsNotFound(err) {
-				logger.Error(err, "failed to get node", "node name", o.GetName())
+				logger.Error(err, "mapper: failed to get node", "node name", o.GetName())
 			}
 			return requests
 		}
 
 		nhcList := &remediationv1alpha1.NodeHealthCheckList{}
 		if err := c.List(context.Background(), nhcList, &client.ListOptions{}); err != nil {
-			logger.Error(err, "failed to list NHCs")
+			logger.Error(err, "mapper: failed to list NHCs")
 			return requests
 		}
 
 		for _, nhc := range nhcList.Items {
 			selector, err := metav1.LabelSelectorAsSelector(&nhc.Spec.Selector)
 			if err != nil {
-				logger.Error(err, "invalid node selector", "NHC name", nhc.GetName())
+				logger.Error(err, "mapper: invalid node selector", "NHC name", nhc.GetName())
 				continue
 			}
 
@@ -51,6 +51,24 @@ func NHCByNodeMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: nhc.GetName()}})
 			}
 		}
+		return requests
+	}
+	return delegate
+}
+
+// NHCByRemediationCRMapperFunc return the RemediationCR-to-NHC mapper function
+func NHCByRemediationCRMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
+	// This closure is meant to get the NHC for the given remediation CR
+	delegate := func(o client.Object) []reconcile.Request {
+		requests := make([]reconcile.Request, 0)
+		for _, owner := range o.GetOwnerReferences() {
+			if owner.Kind == "NodeHealthCheck" && owner.APIVersion == remediationv1alpha1.GroupVersion.String() {
+				logger.Info("mapper: found NHC for remediation CR", "NHC Name", owner.Name, "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: owner.Name}})
+				return requests
+			}
+		}
+		logger.Info("mapper: didn't find NHC for remediation CR", "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
 		return requests
 	}
 	return delegate


### PR DESCRIPTION
Quicker timeout for remediations when they set their "Processing" condition to "False": in case that happens, NHC will wait for a hardcoded timeout (30s), and when the node doesn't get healthy within that timeout, NHC will try the next remediation.

[ECOPROJECT-1214](https://issues.redhat.com//browse/ECOPROJECT-1214)