### PR TITLE
Fix duplicate remediation for remediators cause node recreation

### DIFF
--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -107,10 +107,7 @@ func (m *manager) GenerateRemediationCR(node *corev1.Node, nhc *remediationv1alp
 			} else {
 				// What to do if namespaces don't match?
 				// So far this is a known issue for Metal3 remediation only, and that case was checked already
-				// in the Reconciler. So just log it, but do not fail remediation.
-				m.log.Info("Not setting remediation CR's owner ref to the machine, because namespaces don't match",
-					"template ns", remediationCR.GetNamespace(),
-					"machine ns", machineNamespace)
+				// in the Reconciler. So ignore, logging it is too verbose.
 			}
 		}
 	}


### PR DESCRIPTION
When a remediator deletes and recreates the unhealthy node (e.g. by deleting / reprovisioning its machine), the node conditions on the just created node might not be set correctly yet, which can cause false unhealthy evaluation, and incorrect remediation CR deletion + recreation.

Fixed by:
a) ignoring node creation events
b) ensuring that at least the Ready condition exists, before queueing the node

[ECOPROJECT-205](https://issues.redhat.com//browse/ECOPROJECT-205)
[ECOPROJECT-1202](https://issues.redhat.com//browse/ECOPROJECT-1202)