### PR TITLE
Don't have mandatory fields in status

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -189,15 +189,15 @@ type EscalatingRemediation struct {
 type NodeHealthCheckStatus struct {
 	// ObservedNodes specified the number of nodes observed by using the NHC spec.selector
 	//
-	//+kubebuilder:default:=0
+	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status
-	ObservedNodes int `json:"observedNodes"`
+	ObservedNodes int `json:"observedNodes,omitempty"`
 
 	// HealthyNodes specified the number of healthy nodes observed
 	//
-	//+kubebuilder:default:=0
+	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status
-	HealthyNodes int `json:"healthyNodes"`
+	HealthyNodes int `json:"healthyNodes,omitempty"`
 
 	// UnhealthyNodes tracks currently unhealthy nodes and their remediations.
 	//

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -342,7 +342,6 @@ spec:
                   type: object
                 type: array
               healthyNodes:
-                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -353,7 +352,6 @@ spec:
                   triggered per node. Deprecated in favour of UnhealthyNodes.
                 type: object
               observedNodes:
-                default: 0
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selector
                 type: integer
@@ -442,9 +440,6 @@ spec:
                   - name
                   type: object
                 type: array
-            required:
-            - healthyNodes
-            - observedNodes
             type: object
         type: object
     served: true

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -341,7 +341,6 @@ spec:
                   type: object
                 type: array
               healthyNodes:
-                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -352,7 +351,6 @@ spec:
                   triggered per node. Deprecated in favour of UnhealthyNodes.
                 type: object
               observedNodes:
-                default: 0
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selector
                 type: integer
@@ -441,9 +439,6 @@ spec:
                   - name
                   type: object
                 type: array
-            required:
-            - healthyNodes
-            - observedNodes
             type: object
         type: object
     served: true


### PR DESCRIPTION
In some edge cases, observedNodes and healthyNodes isn't set by older NHC versions, which breaks updates to newer versions. Also, (at least new) default values don't work on (status only?) fields.