### PR TITLE
Don't create console manifests on k8s

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -135,8 +135,6 @@ jobs:
         sleep 30s
         kubectl rollout status daemonset -n ${DEPLOY_NAMESPACE} self-node-remediation-ds --timeout 300s
         kubectl wait deployment -n ${DEPLOY_NAMESPACE} node-healthcheck-controller-manager --for condition=Available=True --timeout=300s
-        # should be scaled down to zero by NHC on k8s
-        kubectl wait deployment -n ${DEPLOY_NAMESPACE} node-healthcheck-node-remediation-console-plugin --for condition=Available=True --timeout=60s
 
     - name: Deployment status
       if: ${{ always() }}

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -235,8 +235,6 @@ spec:
           verbs:
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - config.openshift.io
@@ -262,14 +260,6 @@ spec:
           - ""
           resources:
           - nodes
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
           verbs:
           - get
           - list

--- a/config/console-plugin/kustomization.yaml
+++ b/config/console-plugin/kustomization.yaml
@@ -14,3 +14,9 @@ images:
 - name: console-plugin
   newName: quay.io/medik8s/node-remediation-console
   newTag: latest
+
+# copied from default after removing it from there
+namePrefix: node-healthcheck-
+
+commonLabels:
+  app.kubernetes.io/name: node-healthcheck-operator

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,7 +21,6 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-- ../console-plugin
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook

--- a/config/manifests-ocp/kustomization.yaml
+++ b/config/manifests-ocp/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../manifests
+- ../console-plugin

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,8 +12,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - config.openshift.io
@@ -39,14 +37,6 @@ rules:
   - ""
   resources:
   - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
   verbs:
   - get
   - list

--- a/controllers/console/plugin.go
+++ b/controllers/console/plugin.go
@@ -22,11 +22,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -58,22 +55,7 @@ func CreateOrUpdatePlugin(ctx context.Context, cl client.Client, config *rest.Co
 	if isOpenshift, err := utils.IsOnOpenshift(config); err != nil {
 		return errors.Wrap(err, "failed to check if we are on Openshift")
 	} else if !isOpenshift {
-		log.Info("we are not on Openshift, skipping console plugin activation, but scale down console deployment")
-		list := &v1.DeploymentList{}
-		selector := labels.NewSelector()
-		req, _ := labels.NewRequirement("app.kubernetes.io/component", selection.Equals, []string{"node-remediation-console-plugin"})
-		selector = selector.Add(*req)
-		if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: selector, Namespace: namespace}); err != nil || len(list.Items) != 1 {
-			return errors.Wrap(err, "failed to find console deployment for scaling down")
-		}
-		console := list.Items[0]
-		consoleOrig := console.DeepCopy()
-		replicas := int32(0)
-		console.Spec.Replicas = &replicas
-		mergeFrom := client.MergeFrom(consoleOrig)
-		if err = cl.Patch(ctx, &console, mergeFrom, &client.PatchOptions{}); err != nil {
-			return errors.Wrap(err, "failed to patch console deployment for scaling down")
-		}
+		log.Info("we are not on Openshift, skipping console plugin activation")
 		return nil
 	}
 

--- a/controllers/console/plugin.go
+++ b/controllers/console/plugin.go
@@ -42,8 +42,6 @@ const (
 )
 
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 
 // CreateOrUpdatePlugin creates or updates the resources needed for the remediation console plugin.
 // HEADS UP: consider cleanup of old resources in case of name changes or removals!

--- a/controllers/rbac/aggregation.go
+++ b/controllers/rbac/aggregation.go
@@ -20,6 +20,7 @@ const (
 
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 
 // Aggregation defines the functions needed for setting up RBAC aggregation
 type Aggregation interface {


### PR DESCRIPTION
Causes issues on upgrades, when the old comtroller pod isn't scaled down yet because of failed console pods, and the new controller pod isn't leader yet for scaling down the console deployment.

Not deploying the console at all on k8s is the much better solution.