### PR TITLE
Add conversionReviewVersions for the webhook in CRD

### DIFF
--- a/config/crd/patches/webhook_in_nodehealthchecks.yaml
+++ b/config/crd/patches/webhook_in_nodehealthchecks.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
The CRD manifest generate using kustomize is getting rejected with validation error from api server:
```
error validating data: ValidationError(CustomResourceDefinition.spec.conversion.webhook): missing required field "conversionReviewVersions" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion; if you choose to ignore these errors, turn validation off with --validate=false
```
As per https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#request conversionReviewVersions is a required field when creating apiextensions.k8s.io/v1 custom resource definitions. Webhooks are required to support at least one ConversionReview version understood by the current and previous API server.