### PR TITLE
Fix requeue for unhealthy condition duration

### DIFF
--- a/controllers/utils/mapper.go
+++ b/controllers/utils/mapper.go
@@ -48,6 +48,7 @@ func NHCByNodeMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
 			}
 
 			if selector.Matches(labels.Set(node.GetLabels())) {
+				logger.Info("adding NHC to reconcile queue for handling node", "node", node.GetName(), "NHC", nhc.GetName())
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: nhc.GetName()}})
 			}
 		}

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -48,4 +49,15 @@ func IsOnOpenshift(config *rest.Config) (bool, error) {
 // GetLogWithNHC return a logger with NHC namespace and name
 func GetLogWithNHC(log logr.Logger, nhc *v1alpha1.NodeHealthCheck) logr.Logger {
 	return log.WithValues("NodeHealthCheck name", nhc.Name)
+}
+
+// MinDuration returns the minimal duration
+func MinDuration(old, new *time.Duration) *time.Duration {
+	if new == nil {
+		return old
+	}
+	if old == nil || *new < *old {
+		return new
+	}
+	return old
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	remediationStartedTimeout = 2 * time.Minute
-	nodeRebootedTimeout       = 10 * time.Minute
-	nhcName                   = "test-nhc"
+	unhealthyConditionDuration = 90 * time.Second
+	nodeRebootedTimeout        = 10 * time.Minute
+	nhcName                    = "test-nhc"
 )
 
 var (
@@ -75,12 +75,12 @@ var _ = Describe("e2e", func() {
 					{
 						Type:     "Ready",
 						Status:   "False",
-						Duration: metav1.Duration{Duration: 10 * time.Second},
+						Duration: metav1.Duration{Duration: unhealthyConditionDuration},
 					},
 					{
 						Type:     "Ready",
 						Status:   "Unknown",
-						Duration: metav1.Duration{Duration: 10 * time.Second},
+						Duration: metav1.Duration{Duration: unhealthyConditionDuration},
 					},
 				},
 			},
@@ -180,45 +180,12 @@ var _ = Describe("e2e", func() {
 		})
 	})
 
-	Context("with terminating node", labelOcpOnly, func() {
-		BeforeEach(func() {
-			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
-			conditions := nodeUnderTest.Status.Conditions
-			conditions = append(conditions, v1.NodeCondition{
-				Type:   mhc.NodeConditionTerminating,
-				Status: "True",
-			})
-			nodeUnderTest.Status.Conditions = conditions
-			Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
-
-			makeNodeUnready(nodeUnderTest)
-		})
-
-		AfterEach(func() {
-			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
-			conditions := nodeUnderTest.Status.Conditions
-			for i, cond := range conditions {
-				if cond.Type == mhc.NodeConditionTerminating {
-					conditions = append(conditions[:i], conditions[i+1:]...)
-					break
-				}
-			}
-			nodeUnderTest.Status.Conditions = conditions
-			Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
-		})
-
-		It("should not remediate", func() {
-			Consistently(
-				fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), remediationStartedTimeout, 30*time.Second).
-				ShouldNot(Succeed())
-		})
-	})
-
 	When("Node conditions meets the unhealthy criteria", func() {
 
 		Context("with escalating remediation config", func() {
 
 			firstTimeout := metav1.Duration{Duration: 1 * time.Minute}
+			var nodeUnhealthyTime time.Time
 
 			BeforeEach(func() {
 				// modify nhc to use escalating remediations
@@ -242,16 +209,17 @@ var _ = Describe("e2e", func() {
 							Namespace:  operatorNsName,
 						},
 						Order:   5,
-						Timeout: metav1.Duration{Duration: 5 * time.Minute},
+						Timeout: metav1.Duration{Duration: unhealthyConditionDuration},
 					},
 				}
 			})
 
 			It("Remediates a host", func() {
 				By("making node unhealthy")
-				makeNodeUnready(nodeUnderTest)
+				nodeUnhealthyTime = makeNodeUnready(nodeUnderTest)
 
 				By("ensuring 1st remediation CR exists")
+				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
 				Eventually(
 					fetchRemediationResourceByName(nodeUnderTest.Name,
 						schema.GroupVersionResource{
@@ -264,7 +232,7 @@ var _ = Describe("e2e", func() {
 							Version:  dummyRemediationGVK.Version,
 							Resource: strings.ToLower(dummyRemediationGVK.Kind) + "s",
 						},
-					), remediationStartedTimeout, 5*time.Second).
+					), waitTime, 1*time.Second).
 					Should(Succeed())
 
 				// SNR is very fast on kind, so use a short poll intervals, otherwise node might already be healthy again
@@ -278,11 +246,11 @@ var _ = Describe("e2e", func() {
 					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1), "expected unhealthy node!")
 					log.Info("checking timeout", "node", nhc.Status.UnhealthyNodes[0].Name, "remediation kind", nhc.Status.UnhealthyNodes[0].Remediations[0].Resource.Kind, "timedOut", nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut)
 					return nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut
-				}, "20s", "500ms").ShouldNot(BeNil(), "1st remediation should have timed out")
+				}, "5s", "500ms").ShouldNot(BeNil(), "1st remediation should have timed out")
 
 				By("ensuring 2nd remediation CR exists")
 				Eventually(
-					fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), remediationStartedTimeout, "500ms").
+					fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), "2s", "500ms").
 					Should(Succeed())
 
 				By("ensuring status is set")
@@ -292,7 +260,7 @@ var _ = Describe("e2e", func() {
 					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
 					g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(2))
 					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
-				}, "10s", "500ms").Should(Succeed())
+				}, "2s", "500ms").Should(Succeed())
 
 				By("waiting for healthy node")
 				waitForNodeHealthyCondition(nodeUnderTest, v1.ConditionTrue)
@@ -301,17 +269,20 @@ var _ = Describe("e2e", func() {
 
 		Context("with classic remediation config", func() {
 
+			var nodeUnhealthyTime time.Time
+
 			BeforeEach(func() {
 				nodeUnderTest = node2
 			})
 
 			It("Remediates a host and prevents config updates", func() {
 				By("making node unhealthy")
-				makeNodeUnready(nodeUnderTest)
+				nodeUnhealthyTime = makeNodeUnready(nodeUnderTest)
 
 				By("ensuring remediation CR exists")
+				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
 				Eventually(
-					fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), remediationStartedTimeout, "500ms").
+					fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), waitTime, "500ms").
 					Should(Succeed())
 
 				By("ensuring status is set")
@@ -324,7 +295,6 @@ var _ = Describe("e2e", func() {
 				}, "10s", "500ms").Should(Succeed())
 
 				// let's do some NHC validation tests here
-				// wrap 1st webhook test in eventually in order to wait until webhook is up and running
 				By("ensuring negative minHealthy update fails")
 				nhc = getConfig()
 				negValue := intstr.FromInt(-1)
@@ -352,7 +322,42 @@ var _ = Describe("e2e", func() {
 
 				By("waiting for healthy node")
 				waitForNodeHealthyCondition(nodeUnderTest, v1.ConditionTrue)
+			})
+		})
 
+		// Run this as last one, since the node won't be remediated!
+		Context("with terminating node", labelOcpOnly, func() {
+
+			BeforeEach(func() {
+				Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
+				conditions := nodeUnderTest.Status.Conditions
+				conditions = append(conditions, v1.NodeCondition{
+					Type:   mhc.NodeConditionTerminating,
+					Status: "True",
+				})
+				nodeUnderTest.Status.Conditions = conditions
+				Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
+
+				makeNodeUnready(nodeUnderTest)
+			})
+
+			AfterEach(func() {
+				Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
+				conditions := nodeUnderTest.Status.Conditions
+				for i, cond := range conditions {
+					if cond.Type == mhc.NodeConditionTerminating {
+						conditions = append(conditions[:i], conditions[i+1:]...)
+						break
+					}
+				}
+				nodeUnderTest.Status.Conditions = conditions
+				Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
+			})
+
+			It("should not remediate", func() {
+				Consistently(
+					fetchRemediationResourceByName(nodeUnderTest.Name, remediationTemplateGVR, remediationGVR), unhealthyConditionDuration+60*time.Second, 10*time.Second).
+					ShouldNot(Succeed())
 			})
 		})
 
@@ -386,19 +391,20 @@ func getTemplateNS(templateResource schema.GroupVersionResource) string {
 	return list.Items[0].GetNamespace()
 }
 
-func makeNodeUnready(node *v1.Node) {
+func makeNodeUnready(node *v1.Node) time.Time {
 	log.Info("making node unready", "node name", node.GetName())
 	// check if node is unready already
 	Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(node), node)).To(Succeed())
 	for _, cond := range node.Status.Conditions {
 		if cond.Type == v1.NodeReady && cond.Status == v1.ConditionUnknown {
 			log.Info("node is already unready", "node name", node.GetName())
-			return
+			return cond.LastTransitionTime.Time
 		}
 	}
 	Expect(modifyKubelet(node, "stop")).To(Succeed())
-	waitForNodeHealthyCondition(node, v1.ConditionUnknown)
+	transitionTime := waitForNodeHealthyCondition(node, v1.ConditionUnknown)
 	log.Info("node is unready", "node name", node.GetName())
+	return transitionTime
 }
 
 func modifyKubelet(node *v1.Node, what string) error {
@@ -411,14 +417,17 @@ func modifyKubelet(node *v1.Node, what string) error {
 	return err
 }
 
-func waitForNodeHealthyCondition(node *v1.Node, status v1.ConditionStatus) {
+func waitForNodeHealthyCondition(node *v1.Node, status v1.ConditionStatus) time.Time {
+	var transitionTime time.Time
 	Eventually(func() v1.ConditionStatus {
 		Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(node), node)).To(Succeed())
 		for _, cond := range node.Status.Conditions {
 			if cond.Type == v1.NodeReady {
+				transitionTime = cond.LastTransitionTime.Time
 				return cond.Status
 			}
 		}
 		return v1.ConditionStatus("failure")
-	}, nodeRebootedTimeout, 15*time.Second).Should(Equal(status))
+	}, nodeRebootedTimeout, 1*time.Second).Should(Equal(status))
+	return transitionTime
 }


### PR DESCRIPTION
NHC misses to requeue for unhealthy condition duration.
Another reconcile (unknow trigger so far) triggers remediation, but with a potential delay.

- 1st commit: Add logs, and make test timeouts more restrictive, in order to signal the issue
- 2nd: fix the bug
- 3rd: fix flaky failure when cluster is already cleaned up 
- 4th: improve unit tests to cover the fixed bug
- TODO for a follow up: find reason for unwanted reconciles

[ECOPROJECT-1349](https://issues.redhat.com//browse/ECOPROJECT-1349)