### PR TITLE
Remove regular syncs

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -86,6 +86,7 @@ type NodeHealthCheckReconciler struct {
 	ClusterUpgradeStatusChecker cluster.UpgradeChecker
 	MHCChecker                  mhc.Checker
 	OnOpenShift                 bool
+	MHCEvents                   chan event.GenericEvent
 	ctrl                        controller.Controller
 	watches                     map[string]struct{}
 	watchesLock                 sync.Mutex
@@ -108,6 +109,10 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					GenericFunc: func(_ event.GenericEvent) bool { return false },
 				},
 			),
+		).
+		Watches(
+			&source.Channel{Source: r.MHCEvents},
+			handler.EnqueueRequestsFromMapFunc(utils.NHCByMHCEventMapperFunc(mgr.GetClient(), mgr.GetLogger())),
 		).
 		Build(r)
 
@@ -234,7 +239,6 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.Recorder.Eventf(nhc, eventTypeWarning, eventReasonDisabled, "Custom MachineHealthCheck(s) detected, disabling NodeHealthCheck to avoid conflicts")
 		}
 		// stop reconciling
-		// TODO either requeue here, or trigger reconcile in mhc.Checker.UpdateStatus() for quicker NHC status updates
 		return result, nil
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -165,15 +165,12 @@ var _ = Describe("e2e", func() {
 			}
 			Expect(k8sClient.Create(context.Background(), mhc)).To(Succeed(), "failed to create MHC")
 
-			// status is only updated when something triggers reconcile, so we need to wait a long time...
-			// see TODO after NHC controller "r.MHCChecker.NeedDisableNHC()" call
-
 			By("waiting for NHC to be disabled")
 			Eventually(func(g Gomega) {
 				nhc = getConfig()
 				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
 				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
-			}, 3*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
+			}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
 
 			By("deleting the MHC")
 			Expect(k8sClient.Delete(context.Background(), mhc)).To(Succeed(), "failed to delete MHC")
@@ -183,7 +180,7 @@ var _ = Describe("e2e", func() {
 				nhc = getConfig()
 				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
 				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
-			}, 3*time.Minute, 5*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
+			}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -113,7 +114,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mhcChecker, err := mhc.NewMHCChecker(mgr, onOpenshift)
+	mhcEvents := make(chan event.GenericEvent)
+	mhcChecker, err := mhc.NewMHCChecker(mgr, onOpenshift, mhcEvents)
 	if err != nil {
 		setupLog.Error(err, "unable initialize MHC checker")
 		os.Exit(1)
@@ -131,6 +133,7 @@ func main() {
 		ClusterUpgradeStatusChecker: upgradeChecker,
 		MHCChecker:                  mhcChecker,
 		OnOpenShift:                 onOpenshift,
+		MHCEvents:                   mhcEvents,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeHealthCheck")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"go.uber.org/zap/zapcore"
 
@@ -52,9 +51,8 @@ import (
 )
 
 var (
-	scheme     = pkgruntime.NewScheme()
-	setupLog   = ctrl.Log.WithName("setup")
-	syncPeriod = time.Second * 60
+	scheme   = pkgruntime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
@@ -97,7 +95,6 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "e1f13584.medik8s.io",
-		SyncPeriod:             &syncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
SyncPeriod of 1 minute isn't needed, all reconciles should be event based.
This a leftover from a very old version...

Side effect: updates on MHCs didn't cause a status update anymore. Use a channel source for doing this. 

[ECOPROJECT-1349](https://issues.redhat.com//browse/ECOPROJECT-1349)