### PR TITLE
Skip escalating e2e test on k8s

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -189,7 +189,7 @@ var _ = Describe("e2e", func() {
 
 	When("Node conditions meets the unhealthy criteria", func() {
 
-		Context("with escalating remediation config", func() {
+		Context("with escalating remediation config", labelOcpOnly, func() {
 
 			firstTimeout := metav1.Duration{Duration: 1 * time.Minute}
 			var nodeUnhealthyTime time.Time


### PR DESCRIPTION
Save test resource usage and get the k8s e2e test green again