### PR TITLE
Replaced '+patchMergeKey' and '+patchStrategy' with '+listType' and +listMapKey' markers.

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -72,8 +72,9 @@ type NodeHealthCheckSpec struct {
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
 	//+optional
-	//+patchStrategy=merge
-	//+patchMergeKey=type
+	//+listType=map
+	//+listMapKey=type
+	//+listMapKey=status
 	//+kubebuilder:default:={{type:Ready,status:False,duration:"300s"},{type:Ready,status:Unknown,duration:"300s"}}
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
@@ -201,8 +202,8 @@ type NodeHealthCheckStatus struct {
 
 	// UnhealthyNodes tracks currently unhealthy nodes and their remediations.
 	//
-	//+patchStrategy=merge
-	//+patchMergeKey=type
+	//+listType=map
+	//+listMapKey=name
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	UnhealthyNodes []*UnhealthyNode `json:"unhealthyNodes,omitempty"`
@@ -217,8 +218,8 @@ type NodeHealthCheckStatus struct {
 	// Represents the observations of a NodeHealthCheck's current state.
 	// Known .status.conditions.type are: "Disabled"
 	//
-	//+patchStrategy=merge
-	//+patchMergeKey=type
+	//+listType=map
+	//+listMapKey=type
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:io.kubernetes.conditions"
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -249,8 +250,6 @@ type UnhealthyNode struct {
 
 	// Remediations tracks the remediations created for this node
 	//
-	//+patchStrategy=merge
-	//+patchMergeKey=type
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	Remediations []*Remediation `json:"remediations,omitempty"`

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -267,6 +267,10 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - status
+                x-kubernetes-list-type: map
             type: object
           status:
             description: NodeHealthCheckStatus defines the observed state of NodeHealthCheck
@@ -341,6 +345,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               healthyNodes:
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
@@ -440,6 +447,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -265,6 +265,10 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - status
+                x-kubernetes-list-type: map
             type: object
           status:
             description: NodeHealthCheckStatus defines the observed state of NodeHealthCheck
@@ -339,6 +343,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               healthyNodes:
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
@@ -438,6 +445,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true


### PR DESCRIPTION
Replaced '+patchMergeKey' and '+patchStrategy' with '+listType' and +listMapKey' markers.
According to https://github.com/kubernetes-sigs/gateway-api/issues/342 the markers +patchMergeKey' and '+patchStrategy' don't work on CRDs.
Now the CRD yaml has changed and we have these additions for example: 
```
x-kubernetes-list-map-keys:
- name
x-kubernetes-list-type: map
```
             