### PR TITLE
Metric for node unhealty duration statistics

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -323,6 +323,9 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				log.Info("deleted remediation CR", "name", remediationCR.GetName())
 				r.Recorder.Eventf(nhc, eventTypeNormal, eventReasonRemediationRemoved, "Deleted remediation CR for node %s", remediationCR.GetName())
 				metrics.ObserveNodeHealthCheckRemediationDeleted(node.GetName(), remediationCR.GetNamespace(), remediationCR.GetKind())
+
+				duration := time.Now().Sub(remediationCR.GetCreationTimestamp().Time)
+				metrics.ObserveNodeHealthCheckUnhealthyNodeDuration(node.GetName(), remediationCR.GetNamespace(), remediationCR.GetKind(), duration)
 			}
 
 			// always update status, in case patching it failed during last reconcile

--- a/metrics/nodehealthcheck.go
+++ b/metrics/nodehealthcheck.go
@@ -16,15 +16,17 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
-	// NodeHealthCheckOldRemediationCR is a Prometheus metric, which reports the number of old Remediation CRs.
+	// nodeHealthCheckOldRemediationCR is a Prometheus metric, which reports the number of old Remediation CRs.
 	// It is an indication for remediation that is pending for a long while, which might indicate a problem with the external remediation mechanism.
-	NodeHealthCheckOldRemediationCR = prometheus.NewCounterVec(
+	nodeHealthCheckOldRemediationCR = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "nodehealthcheck_old_remediation_cr",
 			Help: "Number of old remediation CRs detected by NodeHealthChecks",
@@ -33,8 +35,8 @@ var (
 )
 
 var (
-	// NodeHealthCheckOngoingRemediation is a Prometheus metric, which reports an ongoing remediation of a node
-	NodeHealthCheckOngoingRemediation = prometheus.NewGaugeVec(
+	// nodeHealthCheckOngoingRemediation is a Prometheus metric, which reports an ongoing remediation of a node
+	nodeHealthCheckOngoingRemediation = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "nodehealthcheck_ongoing_remediation",
 			Help: "Indication of an ongoing remediation of an unhealthy node",
@@ -42,22 +44,34 @@ var (
 	)
 )
 
+var (
+	// nodehealtCheckRemediationDuration is a Prometheus metric, which reports the unhealthy node duration
+	nodehealtCheckRemediationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "nodehealthcheck_unhealthy_node_duration_seconds",
+			Help:    "Unhealthy Node duration distribution",
+			Buckets: []float64{30, 60, 120, 180, 240, 300, 600, 1200, 2400, 3600},
+		}, []string{"name", "namespace", "remediation"},
+	)
+)
+
 func InitializeNodeHealthCheckMetrics() {
 	metrics.Registry.MustRegister(
-		NodeHealthCheckOldRemediationCR,
-		NodeHealthCheckOngoingRemediation,
+		nodeHealthCheckOldRemediationCR,
+		nodeHealthCheckOngoingRemediation,
+		nodehealtCheckRemediationDuration,
 	)
 }
 
 func ObserveNodeHealthCheckOldRemediationCR(name, namespace string) {
-	NodeHealthCheckOldRemediationCR.With(prometheus.Labels{
+	nodeHealthCheckOldRemediationCR.With(prometheus.Labels{
 		"name":      name,
 		"namespace": namespace,
 	}).Inc()
 }
 
 func ObserveNodeHealthCheckRemediationCreated(name, namespace, remediation string) {
-	NodeHealthCheckOngoingRemediation.With(prometheus.Labels{
+	nodeHealthCheckOngoingRemediation.With(prometheus.Labels{
 		"name":        name,
 		"namespace":   namespace,
 		"remediation": remediation,
@@ -65,9 +79,17 @@ func ObserveNodeHealthCheckRemediationCreated(name, namespace, remediation strin
 }
 
 func ObserveNodeHealthCheckRemediationDeleted(name, namespace, remediation string) {
-	NodeHealthCheckOngoingRemediation.With(prometheus.Labels{
+	nodeHealthCheckOngoingRemediation.With(prometheus.Labels{
 		"name":        name,
 		"namespace":   namespace,
 		"remediation": remediation,
 	}).Set(0)
+}
+
+func ObserveNodeHealthCheckUnhealthyNodeDuration(name, namespace, remediation string, duration time.Duration) {
+	nodehealtCheckRemediationDuration.With(prometheus.Labels{
+		"name":        name,
+		"namespace":   namespace,
+		"remediation": remediation,
+	}).Observe(duration.Seconds())
 }


### PR DESCRIPTION
Add Prometheus histogram metric to track remediation duration

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
