### PR TITLE
use new SNR labels

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -170,6 +170,6 @@ jobs:
         echo "Debugging SNR agents"
         kubectl describe daemonset -n ${DEPLOY_NAMESPACE} self-node-remediation-ds
         echo "\n\n"
-        kubectl describe pod -n ${DEPLOY_NAMESPACE} --selector=app=self-node-remediation-agent,control-plane=controller-manager
+        kubectl describe pod -n ${DEPLOY_NAMESPACE} --selector=app.kubernetes.io/name=self-node-remediation,app.kubernetes.io/component=agent
         echo "\n\n"
-        kubectl logs -n ${DEPLOY_NAMESPACE} --selector=app=self-node-remediation-agent,control-plane=controller-manager --tail -1
+        kubectl logs -n ${DEPLOY_NAMESPACE} --selector=app.kubernetes.io/name=self-node-remediation,app.kubernetes.io/component=agent --tail -1


### PR DESCRIPTION
This PR dependent on SNR PR: https://github.com/medik8s/self-node-remediation/pull/133 
and E2E expect to pass only after it's merged
Corrections: looks like e2e test pass before  https://github.com/medik8s/self-node-remediation/pull/133  was merged - probably due to skipping some tests when not running on OCP