### PR TITLE
Delete orphaned remediation CRs

### DIFF
--- a/controllers/resources/status.go
+++ b/controllers/resources/status.go
@@ -58,10 +58,10 @@ func UpdateStatusRemediationStarted(node *corev1.Node, nhc *remediationv1alpha1.
 
 }
 
-func UpdateStatusNodeHealthy(node *corev1.Node, nhc *remediationv1alpha1.NodeHealthCheck) {
-	delete(nhc.Status.InFlightRemediations, node.GetName())
+func UpdateStatusNodeHealthy(nodeName string, nhc *remediationv1alpha1.NodeHealthCheck) {
+	delete(nhc.Status.InFlightRemediations, nodeName)
 	for i, _ := range nhc.Status.UnhealthyNodes {
-		if nhc.Status.UnhealthyNodes[i].Name == node.GetName() {
+		if nhc.Status.UnhealthyNodes[i].Name == nodeName {
 			nhc.Status.UnhealthyNodes = append(nhc.Status.UnhealthyNodes[:i], nhc.Status.UnhealthyNodes[i+1:]...)
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4
-	github.com/medik8s/common v1.5.0
+	github.com/medik8s/common v1.7.0
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20221013123534-96eec44e1979 // release-4.11

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.5.0 h1:sAtK2BniRvcjyqcQ5cJnu0uMzkg4LippOsMp9US4/H8=
-github.com/medik8s/common v1.5.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
+github.com/medik8s/common v1.7.0 h1:JwimhWigPTAszGG2jYJmh+uVHq2nFUPRRljw7ZhlQhg=
+github.com/medik8s/common v1.7.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=

--- a/vendor/github.com/medik8s/common/pkg/conditions/conditions.go
+++ b/vendor/github.com/medik8s/common/pkg/conditions/conditions.go
@@ -1,0 +1,13 @@
+package conditions
+
+const (
+
+	// These are condition types used on remediation CRs
+
+	// ProcessingType is the condition type used to signal the remediation has started and it is in progress, or has finished
+	ProcessingType = "Processing"
+	// SucceededType is the condition type used to signal whether the remediation was successful or not
+	SucceededType = "Succeeded"
+	// PermanentNodeDeletionExpectedType is the condition type used to signal that the unhealthy node will be permanently deleted.
+	PermanentNodeDeletionExpectedType = "PermanentNodeDeletionExpected"
+)

--- a/vendor/github.com/medik8s/common/pkg/labels/labels.go
+++ b/vendor/github.com/medik8s/common/pkg/labels/labels.go
@@ -7,8 +7,4 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
-	// ProcessingConditionType is the condition type used to signal the remediation has started and it is in progress, or has finished
-	ProcessingConditionType = "Processing"
-	// SucceededConditionType is the condition type used to signal whether the remediation was successful or not
-	SucceededConditionType = "Succeeded"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,9 +91,10 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.4
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.5.0
+# github.com/medik8s/common v1.7.0
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/annotations
+github.com/medik8s/common/pkg/conditions
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/lease
 github.com/medik8s/common/pkg/nodes


### PR DESCRIPTION
Remedition CRs are considered orphaned when:
- Succeeded condition is true
- NodeNameChangeExpected condition is true
- Node does not exist anymore

[ECOPROJECT-1465](https://issues.redhat.com//browse/ECOPROJECT-1465)