### PR TITLE
Prefer scheduling on OCP infra nodes

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -356,6 +356,11 @@ spec:
                   preferredDuringSchedulingIgnoredDuringExecution:
                   - preference:
                       matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                    weight: 2
+                  - preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/master
                         operator: Exists
                     weight: 1
@@ -423,8 +428,15 @@ spec:
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
+                operator: Exists
               - effect: NoSchedule
                 key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
+              - effect: NoExecute
+                key: node-role.kubernetes.io/infra
                 operator: Exists
       - label:
           app.kubernetes.io/component: node-remediation-console-plugin

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,11 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
             - weight: 1
               preference:
                 matchExpressions:
@@ -41,8 +46,15 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+          operator: Exists
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
           operator: Exists
       priorityClassName: system-cluster-critical
       containers:


### PR DESCRIPTION
Infra nodes are a better fit than control plane nodes on OCP.
See https://docs.openshift.com/container-platform/4.13/machine_management/creating-infrastructure-machinesets.html#moving-resources-to-infrastructure-machinesets

[ECOPROJECT-1472](https://issues.redhat.com//browse/ECOPROJECT-1472)