### PR TITLE
Prevent multiple simultaneously remediation of same node

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -203,7 +203,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	leaseManager, err := resources.NewLeaseManager(r.Client, log)
+	leaseManager, err := resources.NewLeaseManager(r.Client, nhc, log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -583,7 +583,7 @@ var _ = Describe("Node Health Check CR", func() {
 						lease := &coordv1.Lease{}
 						err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(*lease.Spec.HolderIdentity).To(Equal("Node-Healthcheck"))
+						Expect(*lease.Spec.HolderIdentity).To(Equal(fmt.Sprintf("%s-%s", "NodeHealthCheck", underTest.GetName())))
 						Expect(*lease.Spec.LeaseDurationSeconds).To(Equal(int32(2 + 1 /*2 seconds is DefaultLeaseDuration (mocked) + 1 second buffer (mocked)  */)))
 						Expect(lease.Spec.AcquireTime).ToNot(BeNil())
 						Expect(*lease.Spec.AcquireTime).To(Equal(*lease.Spec.RenewTime))

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -446,6 +446,55 @@ var _ = Describe("Node Health Check CR", func() {
 					Expect(underTest.Status.UnhealthyNodes).To(BeEmpty())
 				})
 			})
+
+			When("two NHC CRs with different templates target the same unhealthy node", func() {
+
+				otherTestCRName := "other-test"
+				var otherTestCR *v1alpha1.NodeHealthCheck
+
+				BeforeEach(func() {
+					// prepare other CR but do not create yet, in order to have a predictable order of things to happen
+					otherTestCR = underTest.DeepCopy()
+					otherTestCR.SetName(otherTestCRName)
+					otherTestCR.Spec.RemediationTemplate = &v1.ObjectReference{
+						Kind:       "Metal3RemediationTemplate",
+						Namespace:  MachineNamespace,
+						Name:       "ok",
+						APIVersion: "test.medik8s.io/v1alpha1",
+					}
+
+					setupObjects(1, 2, true)
+				})
+
+				It("only one NHC should remediate that node", func() {
+
+					By("Verifying node is remediated by 1st NHC")
+					Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
+					Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
+					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
+					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
+
+					By("Creating a 2nd NHC")
+					Expect(k8sClient.Create(context.Background(), otherTestCR)).To(Succeed())
+					DeferCleanup(func() {
+						Expect(k8sClient.Delete(context.Background(), otherTestCR)).To(Succeed())
+					})
+					By("Verifying node is NOT remediated by 2nd NHC")
+					// wait for unhealthy node
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(otherTestCR), otherTestCR)).To(Succeed())
+						g.Expect(otherTestCR.Status.UnhealthyNodes).To(HaveLen(1))
+					}, "5s", "1s").Should(Succeed(), "unhealthy node not detected")
+					// ensure no remediation starts
+					Consistently(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(otherTestCR), otherTestCR)).To(Succeed())
+						g.Expect(otherTestCR.Status.InFlightRemediations).To(HaveLen(0))
+						g.Expect(otherTestCR.Status.UnhealthyNodes).To(HaveLen(1))
+						g.Expect(otherTestCR.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
+					}, "5s", "1s").Should(Succeed(), "duplicate remediation detected!")
+				})
+			})
+
 		}
 
 		Context("with spec.remediationTemplate", func() {

--- a/controllers/resources/status.go
+++ b/controllers/resources/status.go
@@ -69,20 +69,14 @@ func UpdateStatusNodeHealthy(node *corev1.Node, nhc *remediationv1alpha1.NodeHea
 }
 
 func UpdateStatusNodeUnhealthy(node *corev1.Node, nhc *remediationv1alpha1.NodeHealthCheck) {
-	foundNode := false
 	for _, unhealthyNode := range nhc.Status.UnhealthyNodes {
 		if unhealthyNode.Name == node.Name {
-			foundNode = true
-			break
+			return
 		}
-
 	}
-	if !foundNode {
-		nhc.Status.UnhealthyNodes = append(nhc.Status.UnhealthyNodes, &remediationv1alpha1.UnhealthyNode{
-			Name: node.GetName(),
-		})
-
-	}
+	nhc.Status.UnhealthyNodes = append(nhc.Status.UnhealthyNodes, &remediationv1alpha1.UnhealthyNode{
+		Name: node.GetName(),
+	})
 }
 
 // FindStatusRemediation return the first remediation in the NHC's status for the given node which matches the remediationFilter


### PR DESCRIPTION
With multiple NHCs, selecting the same node, but with different
remediator, multiple remediation CRs were created, because they
shared the same lease.

Adding the NHC name to the lease holder identity prevents this.

[ECOPROJECT-1189](https://issues.redhat.com//browse/ECOPROJECT-1189)