### PR TITLE
Prevent using same remediator multiple times

### DIFF
--- a/api/v1alpha1/nodehealthcheck_webhook_test.go
+++ b/api/v1alpha1/nodehealthcheck_webhook_test.go
@@ -144,6 +144,18 @@ var _ = Describe("NodeHealthCheck Validation", func() {
 					Expect(nhc.validate()).To(MatchError(ContainSubstring("42s")))
 				})
 			})
+
+			Context("with duplicate remediator", func() {
+				BeforeEach(func() {
+					setEscalatingRemediations(nhc)
+					nhc.Spec.EscalatingRemediations[1].RemediationTemplate = nhc.Spec.EscalatingRemediations[0].RemediationTemplate
+					nhc.Spec.EscalatingRemediations[1].RemediationTemplate.Name = "dummy"
+				})
+				It("should be denied", func() {
+					Expect(nhc.validate()).To(MatchError(ContainSubstring(uniqueRemediatorError)))
+					Expect(nhc.validate()).To(MatchError(ContainSubstring(nhc.Spec.EscalatingRemediations[1].RemediationTemplate.Kind)))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
Using the same remediator multiple times doesn't work today, because we can't create remediation CRs of the same kind with the same name. Until we find a better solution, prevent creating such NHC CRs.

[ECOPROJECT-1478](https://issues.redhat.com//browse/ECOPROJECT-1478)
