### PR TITLE
Add Node providerID to metric

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -484,8 +484,14 @@ func (r *NodeHealthCheckReconciler) deleteRemediationCR(remediationCR *unstructu
 		r.Recorder.Eventf(nhc, eventTypeNormal, eventReasonRemediationRemoved, "Deleted remediation CR for node %s", remediationCR.GetName())
 		metrics.ObserveNodeHealthCheckRemediationDeleted(remediationCR.GetName(), remediationCR.GetNamespace(), remediationCR.GetKind())
 
+		providerID := "unknown"
+		if annotations := remediationCR.GetAnnotations(); annotations != nil {
+			if v, exists := annotations[utils.NodeProviderIDAnnotation]; exists {
+				providerID = v
+			}
+		}
 		duration := time.Now().Sub(remediationCR.GetCreationTimestamp().Time)
-		metrics.ObserveNodeHealthCheckUnhealthyNodeDuration(remediationCR.GetName(), remediationCR.GetNamespace(), remediationCR.GetKind(), duration)
+		metrics.ObserveNodeHealthCheckUnhealthyNodeDuration(providerID, remediationCR.GetName(), remediationCR.GetNamespace(), remediationCR.GetKind(), duration)
 	}
 
 	// always update status, in case patching it failed during last reconcile

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -20,6 +20,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
 )
 
 const (
@@ -78,6 +79,7 @@ func (m *manager) GenerateRemediationCR(node *corev1.Node, nhc *remediationv1alp
 	remediationCR.SetUID("")
 	remediationCR.SetSelfLink("")
 	remediationCR.SetCreationTimestamp(metav1.Now())
+	remediationCR.SetAnnotations(utils.CreateProviderIdAnnotation(node))
 
 	owners := make([]metav1.OwnerReference, 0)
 	if nhc != nil {

--- a/controllers/utils/annotations.go
+++ b/controllers/utils/annotations.go
@@ -1,0 +1,11 @@
+package utils
+
+import corev1 "k8s.io/api/core/v1"
+
+const NodeProviderIDAnnotation = "nodehealthcheck.medik8s.io/node-provider-id"
+
+func CreateProviderIdAnnotation(node *corev1.Node) map[string]string {
+	annotations := map[string]string{}
+	annotations[NodeProviderIDAnnotation] = node.Spec.ProviderID
+	return annotations
+}

--- a/metrics/nodehealthcheck.go
+++ b/metrics/nodehealthcheck.go
@@ -51,7 +51,7 @@ var (
 			Name:    "nodehealthcheck_unhealthy_node_duration_seconds",
 			Help:    "Unhealthy Node duration distribution",
 			Buckets: []float64{30, 60, 120, 180, 240, 300, 600, 1200, 2400, 3600},
-		}, []string{"name", "namespace", "remediation"},
+		}, []string{"providerID", "name", "namespace", "remediation"},
 	)
 )
 
@@ -86,8 +86,9 @@ func ObserveNodeHealthCheckRemediationDeleted(name, namespace, remediation strin
 	}).Set(0)
 }
 
-func ObserveNodeHealthCheckUnhealthyNodeDuration(name, namespace, remediation string, duration time.Duration) {
+func ObserveNodeHealthCheckUnhealthyNodeDuration(providerID, name, namespace, remediation string, duration time.Duration) {
 	nodehealtCheckRemediationDuration.With(prometheus.Labels{
+		"providerID":  providerID,
 		"name":        name,
 		"namespace":   namespace,
 		"remediation": remediation,


### PR DESCRIPTION
Add Node providerID to NodeHealthCheckUnhealthyNodeDuration metric.

While node name might change after a remediation that deletes the node
(e.g. with Machine-Deletion-Remediation), the ProviderID is expected to
be the same, allowing users to query for the complete history of the
same node after such remediations.

NOTE: ProviderID is expected to change anyway in case of Cloud cluster
providers.

[ECOPROJECT-1479](https://issues.redhat.com/browse/ECOPROJECT-1479)