### PR TITLE
Install monitoring requirements via OLM

### DIFF
--- a/bundle/manifests/node-healthcheck-prometheus-for-nhc-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/node-healthcheck-prometheus-for-nhc-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-prometheus-for-nhc-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/node-healthcheck-prometheus-for-nhc-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/node-healthcheck-prometheus-for-nhc-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-prometheus-for-nhc-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-healthcheck-prometheus-for-nhc-role
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/config/prometheus/clusterrole.yaml
+++ b/config/prometheus/clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-for-nhc-role
+  namespace: openshift-operators
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - services
+      - nodes
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/prometheus/clusterrolebinding.yaml
+++ b/config/prometheus/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-for-nhc-rolebinding
+  namespace: openshift-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-for-nhc-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
 - monitor.yaml
+- clusterrole.yaml
+- clusterrolebinding.yaml
 
 namePrefix: node-healthcheck-
 


### PR DESCRIPTION
- add role/rolebinding for Prometheus Operator ServiceAccount
- add CSV annotation to let Console UI append the required annotation to
  the namespace the operator is deployed to

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
