### PR TITLE
Prevent status triggered reconciles

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -97,7 +97,7 @@ type NodeHealthCheckReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controller, err := ctrl.NewControllerManagedBy(mgr).
-		For(&remediationv1alpha1.NodeHealthCheck{}).
+		For(&remediationv1alpha1.NodeHealthCheck{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&source.Kind{Type: &v1.Node{}},
 			handler.EnqueueRequestsFromMapFunc(utils.NHCByNodeMapperFunc(mgr.GetClient(), mgr.GetLogger())),

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -497,12 +497,8 @@ var _ = Describe("Node Health Check CR", func() {
 					By("faking time and triggering another reconcile")
 					afterTimeout := time.Now().Add(remediationCRAlertTimeout).Add(2 * time.Minute)
 					fakeTime = &afterTimeout
-					labels := underTest.Labels
-					if labels == nil {
-						labels = make(map[string]string)
-					}
-					labels["trigger"] = "now"
-					underTest.Labels = labels
+					newMinHealthy := intstr.FromString("52%")
+					underTest.Spec.MinHealthy = &newMinHealthy
 					Expect(k8sClient.Update(context.Background(), underTest)).To(Succeed())
 					time.Sleep(2 * time.Second)
 


### PR DESCRIPTION
Usually a status update triggers a new reconcile, no matter who updated the status. In a well implemented idempotent Reconcile this isn't a issue, but still a waste of compute power and potential API calls.
Also, the NHC controller is the only component writing to the status.
So it's safe to skip reconcile for status updates.