### PR TITLE
Update kube-rbac-proxy

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -404,7 +404,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                image: quay.io/brancz/kube-rbac-proxy:v0.14.4
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.4
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Fixes http/2 cve

[ECOPROJECT-1733](https://issues.redhat.com//browse/ECOPROJECT-1733)