### PR TITLE
Upgrade kube-rbac-proxy image to v0.15.0 and disable HTTP/2

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -401,10 +401,11 @@ spec:
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
+                - --http2-disable
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: quay.io/brancz/kube-rbac-proxy:v0.14.4
+                image: quay.io/brancz/kube-rbac-proxy:v0.15.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,9 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.4
+        image: quay.io/brancz/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
+        - "--http2-disable"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"


### PR DESCRIPTION
The kube-rbac-proxy image was upgraded to version v0.15.0 in both manager_auth_proxy_patch.yaml and node-healthcheck-operator.clusterserviceversion.yaml. Additionally, a new argument was added to disable HTTP/2 to increase security levels following a recently discovered vulnerability.