### PR TITLE
Update kube rbac proxy and disable http/2 on it

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -299,10 +299,11 @@ spec:
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
+                - --http2-disable
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                image: quay.io/brancz/kube-rbac-proxy:v0.15.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,9 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
+        - "--http2-disable"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"


### PR DESCRIPTION
Mitigates HTTP/2 CVE

ECOPROJECT-1731