### PR TITLE
[release-0.4] Revert "Don't have mandatory fields in status"

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -120,13 +120,13 @@ type UnhealthyCondition struct {
 type NodeHealthCheckStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="observedNodes",xDescriptors="urn:alm:descriptor:com.tectonic.ui:observedNodes"
 	//ObservedNodes specified the number of nodes observed by using the NHC spec.selector
-	//+optional
-	ObservedNodes int `json:"observedNodes,omitempty"`
+	// +kubebuilder:default:=0
+	ObservedNodes int `json:"observedNodes"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="healthynodes",xDescriptors="urn:alm:descriptor:com.tectonic.ui:healthyNodes"
 	//HealthyNodes specified the number of healthy nodes observed
-	//+optional
-	HealthyNodes int `json:"healthyNodes,omitempty"`
+	// +kubebuilder:default:=0
+	HealthyNodes int `json:"healthyNodes"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="inFlightRemediations",xDescriptors="urn:alm:descriptor:com.tectonic.ui:inFlightRemediations"
 	//InFlightRemediations records the timestamp when remediation triggered per node

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -262,6 +262,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               healthyNodes:
+                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -272,6 +273,7 @@ spec:
                   triggered per node
                 type: object
               observedNodes:
+                default: 0
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selector
                 type: integer
@@ -284,6 +286,9 @@ spec:
               reason:
                 description: Reason explains the current phase in more detail.
                 type: string
+            required:
+            - healthyNodes
+            - observedNodes
             type: object
         type: object
     served: true

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -261,6 +261,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               healthyNodes:
+                default: 0
                 description: HealthyNodes specified the number of healthy nodes observed
                 type: integer
               inFlightRemediations:
@@ -271,6 +272,7 @@ spec:
                   triggered per node
                 type: object
               observedNodes:
+                default: 0
                 description: ObservedNodes specified the number of nodes observed
                   by using the NHC spec.selector
                 type: integer
@@ -283,6 +285,9 @@ spec:
               reason:
                 description: Reason explains the current phase in more detail.
                 type: string
+            required:
+            - healthyNodes
+            - observedNodes
             type: object
         type: object
     served: true


### PR DESCRIPTION
This reverts #198 

It was never released in a 0.4.z downstream release, and is a regression for the upcoming CVE release.
Versions >=0.5.z contain the new fix for the initial issue from #144 