### PR TITLE
Prepare MHC support by removing NHC dependencies

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -326,7 +326,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	healthyCount := 0
 	for _, node := range notMatchingNodes {
 		log.Info("handling healthy node", "node", node.GetName())
-		remediationCRs, err := resourceManager.ListRemediationCRs(nhc, func(cr unstructured.Unstructured) bool {
+		remediationCRs, err := resourceManager.ListRemediationCRs(utils.GetAllRemediationTemplates(nhc), func(cr unstructured.Unstructured) bool {
 			return cr.GetName() == node.GetName() && resources.IsOwner(&cr, nhc)
 		})
 		if err != nil {
@@ -413,7 +413,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		finalRequeueAfter = utils.MinRequeueDuration(finalRequeueAfter, requeueAfter)
 
 		// check if we need to alert about a very old remediation CR
-		remediationCRs, err := resourceManager.ListRemediationCRs(nhc, func(cr unstructured.Unstructured) bool {
+		remediationCRs, err := resourceManager.ListRemediationCRs(utils.GetAllRemediationTemplates(nhc), func(cr unstructured.Unstructured) bool {
 			return cr.GetName() == node.GetName() && resources.IsOwner(&cr, nhc)
 		})
 		for _, remediationCR := range remediationCRs {
@@ -481,7 +481,7 @@ func (r *NodeHealthCheckReconciler) matchesUnhealthyConditions(conditionTests []
 }
 
 func (r *NodeHealthCheckReconciler) deleteOrphanedRemediationCRs(nhc *remediationv1alpha1.NodeHealthCheck, allNodes []v1.Node, rm resources.Manager, log logr.Logger) error {
-	orphanedRemediationCRs, err := rm.ListRemediationCRs(nhc, func(cr unstructured.Unstructured) bool {
+	orphanedRemediationCRs, err := rm.ListRemediationCRs(utils.GetAllRemediationTemplates(nhc), func(cr unstructured.Unstructured) bool {
 		// skip already deleted CRs
 		if cr.GetDeletionTimestamp() != nil {
 			return false
@@ -730,7 +730,7 @@ func (r *NodeHealthCheckReconciler) isControlPlaneRemediationAllowed(node *v1.No
 	}
 
 	// check all remediation CRs. If there already is one for another control plane node, skip remediation
-	controlPlaneRemediationCRs, err := rm.ListRemediationCRs(nhc, func(cr unstructured.Unstructured) bool {
+	controlPlaneRemediationCRs, err := rm.ListRemediationCRs(utils.GetAllRemediationTemplates(nhc), func(cr unstructured.Unstructured) bool {
 		_, isControlPlane := cr.GetLabels()[RemediationControlPlaneLabelKey]
 		return isControlPlane && cr.GetName() != node.GetName()
 	})

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -601,8 +601,10 @@ func (r *NodeHealthCheckReconciler) remediate(node *v1.Node, nhc *remediationv1a
 		remediationCR.SetLabels(labels)
 	}
 
+	currentRemediationDuration, previousRemediationsDuration := utils.GetRemediationDuration(nhc, remediationCR)
+
 	// create remediation CR
-	created, leaseRequeueIn, err := rm.CreateRemediationCR(remediationCR, nhc)
+	created, leaseRequeueIn, err := rm.CreateRemediationCR(remediationCR, nhc, currentRemediationDuration, previousRemediationsDuration)
 
 	if err != nil {
 		// An unhealthy node exists, but remediation couldn't be created because lease wasn't obtained

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -1630,11 +1630,11 @@ var _ = Describe("Node Health Check CR", func() {
 
 func mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer time.Duration) {
 	orgRequeueIfLeaseTaken := resources.RequeueIfLeaseTaken
-	orgDefaultLeaseDuration := resources.DefaultLeaseDuration
+	orgDefaultLeaseDuration := utils.DefaultRemediationDuration
 	orgLeaseBuffer := resources.LeaseBuffer
 	//set up mock values so tests can run in a reasonable time
 	resources.RequeueIfLeaseTaken = mockRequeueDurationIfLeaseTaken
-	resources.DefaultLeaseDuration = mockDefaultLeaseDuration
+	utils.DefaultRemediationDuration = mockDefaultLeaseDuration
 	resources.LeaseBuffer = mockLeaseBuffer
 
 	ns := &v1.Namespace{}
@@ -1649,7 +1649,7 @@ func mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, 
 
 	DeferCleanup(func() {
 		resources.RequeueIfLeaseTaken = orgRequeueIfLeaseTaken
-		resources.DefaultLeaseDuration = orgDefaultLeaseDuration
+		utils.DefaultRemediationDuration = orgDefaultLeaseDuration
 		resources.LeaseBuffer = orgLeaseBuffer
 	})
 }

--- a/controllers/resources/lease.go
+++ b/controllers/resources/lease.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,8 +25,6 @@ var (
 	//LeaseBuffer is used to make sure we have a bit of buffer before extending the lease, so it won't be taken by another component
 	LeaseBuffer         = time.Minute
 	RequeueIfLeaseTaken = time.Minute
-	//DefaultLeaseDuration is the default time lease would be held before it would need extending assuming escalation timeout does not exist (i.e. without escalation)
-	DefaultLeaseDuration = 10 * time.Minute
 	//max times lease would be extended - this is a conceptual variable used to calculate max time lease can be held
 	maxTimesToExtendLease = 2
 )
@@ -43,9 +40,9 @@ func (e LeaseOverDueError) Error() string {
 type LeaseManager interface {
 	// ObtainNodeLease will attempt to get a node lease with the correct duration, the duration is affected by whether escalation is used and the remediation timeOut.
 	//The first return value (*time.Duration) is an indicator on when a new reconcile should be scheduled (mainly in order to extend the lease)
-	ObtainNodeLease(remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) (*time.Duration, error)
+	ObtainNodeLease(remediationCR *unstructured.Unstructured, currentRemediationDuration time.Duration) (*time.Duration, error)
 	//ManageLease extends or releases a lease based on the CR status, type of remediation and how long the lease is already leased
-	ManageLease(ctx context.Context, remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) (time.Duration, error)
+	ManageLease(ctx context.Context, remediationCR *unstructured.Unstructured, currentRemediationDuration, previousRemediationsDuration time.Duration) (time.Duration, error)
 	// InvalidateLease invalidates the lease for the node with the given name
 	InvalidateLease(ctx context.Context, nodeName string) error
 }
@@ -72,10 +69,9 @@ func NewLeaseManager(client client.Client, nhc *remediationv1alpha1.NodeHealthCh
 	}, nil
 }
 
-func (m *nhcLeaseManager) ObtainNodeLease(remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) (*time.Duration, error) {
+func (m *nhcLeaseManager) ObtainNodeLease(remediationCR *unstructured.Unstructured, currentRemediationDuration time.Duration) (*time.Duration, error) {
 	nodeName := remediationCR.GetName()
-	leaseDuration := m.getLeaseDurationForRemediation(remediationCR, nhc)
-	leaseDurationWithBuffer := leaseDuration + LeaseBuffer
+	leaseDurationWithBuffer := currentRemediationDuration + LeaseBuffer
 
 	node := &corev1.Node{}
 	if err := m.client.Get(context.Background(), types.NamespacedName{Name: nodeName}, node); err != nil {
@@ -94,11 +90,11 @@ func (m *nhcLeaseManager) ObtainNodeLease(remediationCR *unstructured.Unstructur
 	}
 
 	//all good lease created with wanted duration
-	return &leaseDuration, nil
+	return &currentRemediationDuration, nil
 
 }
 
-func (m *nhcLeaseManager) ManageLease(ctx context.Context, remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) (time.Duration, error) {
+func (m *nhcLeaseManager) ManageLease(ctx context.Context, remediationCR *unstructured.Unstructured, currentRemediationDuration, previousRemediationsDuration time.Duration) (time.Duration, error) {
 	node := &corev1.Node{}
 	if err := m.client.Get(ctx, client.ObjectKey{Name: remediationCR.GetName()}, node); err != nil {
 		m.log.Error(err, "managing lease - couldn't fetch node", "node name", remediationCR.GetName())
@@ -116,7 +112,7 @@ func (m *nhcLeaseManager) ManageLease(ctx context.Context, remediationCR *unstru
 	if !m.isLeaseOwner(nodeLease) {
 		return 0, nil
 	}
-	if isLeaseOverdue, err := m.isLeaseOverdue(nodeLease, nhc, remediationCR); err != nil {
+	if isLeaseOverdue, err := m.isLeaseOverdue(nodeLease, currentRemediationDuration, previousRemediationsDuration, remediationCR); err != nil {
 		return 0, err
 	} else if isLeaseOverdue { //release the lease - lease is overdue
 		m.log.Info("managing lease - lease is overdue about to be removed", "lease name", nodeLease.Name)
@@ -128,19 +124,18 @@ func (m *nhcLeaseManager) ManageLease(ctx context.Context, remediationCR *unstru
 		return 0, LeaseOverDueError{msg: fmt.Sprintf("failed to extend lease, it is overdue. node name: %s", remediationCR.GetName())}
 	}
 
-	leaseExpectedDuration := m.getLeaseDurationForRemediation(remediationCR, nhc)
-	m.log.Info("managing lease - about to try to acquire/extended the lease", "lease name", nodeLease.Name, "NHC is lease owner", m.isLeaseOwner(nodeLease), "lease expiration time", m.calcLeaseExpiration(nodeLease, remediationCR, nhc))
+	m.log.Info("managing lease - about to try to acquire/extended the lease", "lease name", nodeLease.Name, "NHC is lease owner", m.isLeaseOwner(nodeLease), "lease expiration time", currentRemediationDuration)
 	now := time.Now()
-	expectedExpiry := now.Add(leaseExpectedDuration)
+	expectedExpiry := now.Add(currentRemediationDuration)
 	actualExpiry := nodeLease.Spec.RenewTime.Add(time.Second * time.Duration(int(*nodeLease.Spec.LeaseDurationSeconds)))
 	if actualExpiry.Before(expectedExpiry) {
-		err := m.commonLeaseManager.RequestLease(ctx, node, leaseExpectedDuration+LeaseBuffer)
+		err := m.commonLeaseManager.RequestLease(ctx, node, currentRemediationDuration+LeaseBuffer)
 		if err != nil {
 			m.log.Error(err, "couldn't renew lease", "lease name", nodeLease.Name)
 			return 0, err
 		}
 	}
-	return leaseExpectedDuration, nil
+	return currentRemediationDuration, nil
 }
 
 func (m *nhcLeaseManager) InvalidateLease(ctx context.Context, nodeName string) error {
@@ -166,40 +161,19 @@ func (m *nhcLeaseManager) InvalidateLease(ctx context.Context, nodeName string) 
 	return nil
 }
 
-func (m *nhcLeaseManager) getLeaseDurationForRemediation(remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) time.Duration {
-	if timeout := m.getTimeoutForRemediation(remediationCR, nhc); timeout != 0 {
-		return timeout
-	}
-	return DefaultLeaseDuration
-}
-
-func (m *nhcLeaseManager) getTimeoutForRemediation(remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) time.Duration {
-	var leaseDuration time.Duration
-	remediationKind := remediationCR.GetKind()
-	for _, esRemediation := range nhc.Spec.EscalatingRemediations {
-		if strings.TrimSuffix(esRemediation.RemediationTemplate.Kind, "Template") == remediationKind {
-			leaseDuration = esRemediation.Timeout.Duration
-			break
-		}
-	}
-	return leaseDuration
-}
-
-func (m *nhcLeaseManager) isLeaseOverdue(l *coordv1.Lease, nhc *remediationv1alpha1.NodeHealthCheck, remediationCR *unstructured.Unstructured) (bool, error) {
+func (m *nhcLeaseManager) isLeaseOverdue(l *coordv1.Lease, currentRemediationDuration, previousRemediationsDuration time.Duration, remediationCR *unstructured.Unstructured) (bool, error) {
 	if l.Spec.AcquireTime == nil {
 		err := fmt.Errorf("lease Spec.AcquireTime is nil")
 		m.log.Error(err, "lease Spec.AcquireTime is nil", "lease name", l.Name)
 		return false, err
 	}
 
-	isLeaseOverdue := time.Now().After(m.calcLeaseExpiration(l, remediationCR, nhc))
+	isLeaseOverdue := time.Now().After(m.calcLeaseExpiration(l, currentRemediationDuration, previousRemediationsDuration))
 	return isLeaseOverdue, nil
 }
 
-func (m *nhcLeaseManager) calcLeaseExpiration(l *coordv1.Lease, remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) time.Time {
-	leaseDuration := m.getLeaseDurationForRemediation(remediationCR, nhc)
-	prevRemediationsDuration := m.sumPrevRemediationsDuration(remediationCR, nhc)
-	return l.Spec.AcquireTime.Add(time.Duration(maxTimesToExtendLease+1 /*1 is offsetting the lease creation*/)*leaseDuration + prevRemediationsDuration)
+func (m *nhcLeaseManager) calcLeaseExpiration(l *coordv1.Lease, currentRemediationDuration, previousRemediationsDuration time.Duration) time.Time {
+	return l.Spec.AcquireTime.Add(time.Duration(maxTimesToExtendLease+1 /*1 is offsetting the lease creation*/)*currentRemediationDuration + previousRemediationsDuration)
 }
 
 func (m *nhcLeaseManager) isRemediationsExist(remediationCrs []unstructured.Unstructured) bool {
@@ -211,34 +185,4 @@ func (m *nhcLeaseManager) isLeaseOwner(l *coordv1.Lease) bool {
 		return false
 	}
 	return *l.Spec.HolderIdentity == m.holderIdentity
-}
-
-func (m *nhcLeaseManager) sumPrevRemediationsDuration(remediationCR *unstructured.Unstructured, nhc *remediationv1alpha1.NodeHealthCheck) time.Duration {
-	if len(nhc.Spec.EscalatingRemediations) == 0 {
-		return 0
-	}
-
-	var currentEscalatingRemediation *remediationv1alpha1.EscalatingRemediation
-	remediationKind := remediationCR.GetKind()
-	for _, esRemediation := range nhc.Spec.EscalatingRemediations {
-		if strings.TrimSuffix(esRemediation.RemediationTemplate.Kind, "Template") == remediationKind {
-			currentEscalatingRemediation = &esRemediation
-			break
-		}
-	}
-	//remediation isn't found in escalation - should not happen
-	if currentEscalatingRemediation == nil {
-		msg := fmt.Sprintf("existing remediation of kind:%s not found in escalation list: %v", remediationCR.GetKind(), nhc.Spec.EscalatingRemediations)
-		m.log.Error(fmt.Errorf("remediation not found in escalation"), msg)
-		return 0
-	}
-
-	var sumDurations time.Duration
-	for _, esRemediation := range nhc.Spec.EscalatingRemediations {
-		if currentEscalatingRemediation.Order > esRemediation.Order {
-			sumDurations += esRemediation.Timeout.Duration
-		}
-	}
-
-	return sumDurations
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"time"
 
@@ -60,4 +61,15 @@ func MinRequeueDuration(old, new *time.Duration) *time.Duration {
 		return new
 	}
 	return old
+}
+
+func GetAllRemediationTemplates(nhc *v1alpha1.NodeHealthCheck) []*v1.ObjectReference {
+	refs := make([]*v1.ObjectReference, 1)
+	if nhc.Spec.RemediationTemplate != nil {
+		refs = append(refs, nhc.Spec.RemediationTemplate)
+	}
+	for _, rem := range nhc.Spec.EscalatingRemediations {
+		refs = append(refs, &rem.RemediationTemplate)
+	}
+	return refs
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -2,17 +2,24 @@ package utils
 
 import (
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+)
+
+var (
+	// DefaultRemediationDuration is used for node lease calculations for remediations without configured timeout
+	DefaultRemediationDuration = 10 * time.Minute
 )
 
 // GetDeploymentNamespace returns the Namespace this operator is deployed on.
@@ -63,13 +70,49 @@ func MinRequeueDuration(old, new *time.Duration) *time.Duration {
 	return old
 }
 
+// GetAllRemediationTemplates returns a slice of all ObjectReferences used as RemedediationTemplate in the
+// given NodeHealthCheck
 func GetAllRemediationTemplates(nhc *v1alpha1.NodeHealthCheck) []*v1.ObjectReference {
-	refs := make([]*v1.ObjectReference, 1)
 	if nhc.Spec.RemediationTemplate != nil {
-		refs = append(refs, nhc.Spec.RemediationTemplate)
+		return []*v1.ObjectReference{nhc.Spec.RemediationTemplate}
 	}
-	for _, rem := range nhc.Spec.EscalatingRemediations {
-		refs = append(refs, &rem.RemediationTemplate)
+	refs := make([]*v1.ObjectReference, len(nhc.Spec.EscalatingRemediations))
+	for i, rem := range nhc.Spec.EscalatingRemediations {
+		refs[i] = &rem.RemediationTemplate
 	}
 	return refs
+}
+
+// GetRemediationDuration returns the expected remediation duration for the given CR, and all previous used templates
+func GetRemediationDuration(nhc *v1alpha1.NodeHealthCheck, remediationCR *unstructured.Unstructured) (currentRemediationDuration, previousRemediationsDuration time.Duration) {
+
+	if len(nhc.Spec.EscalatingRemediations) == 0 {
+		return DefaultRemediationDuration, 0
+	}
+
+	// find current remediation
+	var currentRemediation *v1alpha1.EscalatingRemediation
+	for _, remediation := range nhc.Spec.EscalatingRemediations {
+		if strings.TrimSuffix(remediation.RemediationTemplate.Kind, "Template") == remediationCR.GetKind() {
+			currentRemediation = &remediation
+			break
+		}
+	}
+
+	if currentRemediation == nil {
+		// should not happen...
+		return DefaultRemediationDuration, 0
+	}
+
+	// get the timeout of the current escalating remediation for currentRemediationDuration
+	currentRemediationDuration = currentRemediation.Timeout.Duration
+
+	// get the sum of timeouts of all previous escalating remediations for previousRemediationsDuration
+	for _, remediation := range nhc.Spec.EscalatingRemediations {
+		if currentRemediation.Order > remediation.Order {
+			previousRemediationsDuration += remediation.Timeout.Duration
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
Remove NHC dependencies in resource and lease manager in order to make it usable for MHC support.
Will make the upcoming MHC PR less complex.