### PR TITLE
Add etcd quorum check for cp node remediation

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -310,6 +310,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,6 +76,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,6 +111,7 @@ var _ = BeforeSuite(func() {
 	Expect(remediationv1alpha1.AddToScheme(testScheme)).To(Succeed())
 	Expect(machinev1beta1.Install(testScheme)).To(Succeed())
 	Expect(apiextensionsv1.AddToScheme(testScheme)).To(Succeed())
+	Expect(policyv1.AddToScheme(testScheme)).To(Succeed())
 	// +kubebuilder:scaffold:scheme
 
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: testScheme})

--- a/controllers/utils/etcd.go
+++ b/controllers/utils/etcd.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	v1 "k8s.io/api/policy/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const etcdNamespace = "openshift-etcd"
+
+// +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;list;watch
+
+// IsEtcdDisruptionAllowed checks if etcd disruption is allowed
+func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, log logr.Logger) (bool, error) {
+	log = log.WithName("etcd-pdb-checker")
+	pdbList := &v1.PodDisruptionBudgetList{}
+	if err := cl.List(ctx, pdbList, &client.ListOptions{Namespace: etcdNamespace}); err != nil {
+		return false, err
+	}
+	if len(pdbList.Items) == 0 {
+		log.Info("No PDB found, can't check if etcd quorum will be violated! Refusing remediation!", "namespace", etcdNamespace)
+		return false, nil
+	}
+	if len(pdbList.Items) > 1 {
+		log.Info("More than one PDB found, can't check if etcd quorum will be violated! Refusing remediation!", "namespace", etcdNamespace)
+		return false, nil
+	}
+	pdb := pdbList.Items[0]
+	if pdb.Status.DisruptionsAllowed >= 1 {
+		log.Info("Etcd disruption is allowed")
+		return true, nil
+	}
+	log.Info("Etcd disruption is not allowed")
+	return false, nil
+}


### PR DESCRIPTION
In order to better protect control plane nodes, add a etcd quorum guard check which can prevent cp node remediation

[ECOPROJECT-1003](https://issues.redhat.com//browse/ECOPROJECT-1003)