### PR TITLE
Fix etcd guard check for control plane remediation

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -302,6 +302,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - machine.openshift.io
           resources:
           - machinehealthchecks

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - machine.openshift.io
   resources:
   - machinehealthchecks

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -675,7 +675,7 @@ func (r *NodeHealthCheckReconciler) isControlPlaneRemediationAllowed(ctx context
 		// etcd quorum PDB is only installed in OpenShift
 		return true, nil
 	}
-	if allowed, err := utils.IsEtcdDisruptionAllowed(ctx, r.Client, r.Log); err != nil {
+	if allowed, err := utils.IsEtcdDisruptionAllowed(ctx, r.Client, r.Log, node); err != nil {
 		return false, err
 	} else if allowed {
 		return true, nil

--- a/controllers/utils/etcd.go
+++ b/controllers/utils/etcd.go
@@ -5,18 +5,22 @@ import (
 
 	"github.com/go-logr/logr"
 
-	v1 "k8s.io/api/policy/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const etcdNamespace = "openshift-etcd"
 
-// +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // IsEtcdDisruptionAllowed checks if etcd disruption is allowed
-func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, log logr.Logger) (bool, error) {
+func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, log logr.Logger, node *corev1.Node) (bool, error) {
 	log = log.WithName("etcd-pdb-checker")
-	pdbList := &v1.PodDisruptionBudgetList{}
+	pdbList := &policyv1.PodDisruptionBudgetList{}
 	if err := cl.List(ctx, pdbList, &client.ListOptions{Namespace: etcdNamespace}); err != nil {
 		return false, err
 	}
@@ -33,6 +37,35 @@ func IsEtcdDisruptionAllowed(ctx context.Context, cl client.Client, log logr.Log
 		log.Info("Etcd disruption is allowed")
 		return true, nil
 	}
-	log.Info("Etcd disruption is not allowed")
+
+	// No disruptions allowed, so the only case we should remediate is that the node in question is already one of the disrupted ones
+	// The PDB doesn't disclose which node is disrupted
+	// So we have to check the etcd guard pods
+	selector, err := metav1.LabelSelectorAsMap(pdb.Spec.Selector)
+	if err != nil {
+		log.Info("Could not parse PDB selector, can't check if etcd quorum will be violated! Refusing remediation!", "selector", pdb.Spec.Selector.String())
+		return false, nil
+	}
+	podList := &corev1.PodList{}
+	if err := cl.List(ctx, podList, &client.ListOptions{
+		Namespace:     etcdNamespace,
+		LabelSelector: labels.SelectorFromSet(selector),
+	}); err != nil {
+		return false, err
+	}
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == node.Name {
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+					log.Info("Etcd disruption not allowed, but the node is already disrupted, so remediation is allowed")
+					return true, nil
+				}
+			}
+			log.Info("Etcd disruption not allowed, but the node is already disrupted, so remediation is allowed")
+			return true, nil
+		}
+	}
+
+	log.Info("Etcd disruption is not allowed, and node is not already disrupted, so remediation is not allowed")
 	return false, nil
 }

--- a/e2e/mhc_e2e_test.go
+++ b/e2e/mhc_e2e_test.go
@@ -27,7 +27,7 @@ const (
 	mhcNamespace = "openshift-machine-api"
 )
 
-var _ = Describe("e2e", Label("MHC", labelOcpOnlyValue), func() {
+var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 	var nodeUnderTest *v1.Node
 	var machineNameUnderTest string
 	var mhc *v1beta1.MachineHealthCheck

--- a/e2e/nhc_console_e2e_test.go
+++ b/e2e/nhc_console_e2e_test.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+
+	"github.com/medik8s/node-healthcheck-operator/controllers/console"
+	"github.com/medik8s/node-healthcheck-operator/e2e/utils"
+)
+
+var _ = Describe("e2e - console", Label("NHC"), func() {
+	When("when the operator and the console plugin is deployed", labelOcpOnly, func() {
+		It("the plugin manifest should be served", func() {
+			By("getting the ConsolePlugin")
+			plugin := &consolev1alpha1.ConsolePlugin{}
+			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: console.PluginName}, plugin)).To(Succeed(), "failed to get ConsolePlugin")
+
+			By("getting the plugin Service")
+			svc := &v1.Service{}
+			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Namespace: plugin.Spec.Service.Namespace, Name: plugin.Spec.Service.Name}, svc)).To(Succeed(), "failed to get plugin Service")
+
+			By("getting the console manifest")
+			manifestUrl := fmt.Sprintf("https://%s:%d/%s/plugin-manifest.json", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port, plugin.Spec.Service.BasePath)
+			cmd := fmt.Sprintf("curl -k %s", manifestUrl)
+			node := utils.GetWorkerNodes(k8sClient)[0]
+			output, err := utils.RunCommandInCluster(clientSet, node.Name, testNsName, cmd, log)
+			Expect(err).ToNot(HaveOccurred())
+			log.Info("got manifest (stripped)", "manifest", output[:100])
+			Expect(output).To(ContainSubstring(console.PluginName), "failed to get correct plugin manifest")
+		})
+	})
+})

--- a/e2e/nhc_e2e_test.go
+++ b/e2e/nhc_e2e_test.go
@@ -95,8 +95,12 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 	})
 
 	Context("With custom MHC", labelOcpOnly, func() {
+
+		var mhc *v1beta1.MachineHealthCheck
+
 		BeforeEach(func() {
-			mhc := &v1beta1.MachineHealthCheck{
+			By("creating custom MHC")
+			mhc = &v1beta1.MachineHealthCheck{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-mhc",
@@ -114,15 +118,18 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), mhc)).To(Succeed(), "failed to create MHC")
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(context.Background(), mhc)).To(Succeed(), "failed to delete MHC")
-				By("waiting for NHC to be re-enabled")
-				Eventually(func(g Gomega) {
-					nhc = getNodeHealthCheck()
-					g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
-					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
-				}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
-			})
+		})
+
+		AfterEach(func() {
+			// don't put this in to deferred cleanup, NHC will be deleted by outer AfterEach first
+			By("deleting custom MHC")
+			Expect(k8sClient.Delete(context.Background(), mhc)).To(Succeed(), "failed to delete MHC")
+			By("waiting for NHC to be re-enabled")
+			Eventually(func(g Gomega) {
+				nhc = getNodeHealthCheck()
+				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
+				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
+			}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
 		})
 
 		It("should report disabled NHC", func() {
@@ -373,6 +380,52 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 			}) // end of terminating node context
 
 		}) // end of worker node context
+
+		Context("Control plane node with unhealthy condition, with classic remediation", func() {
+			BeforeEach(func() {
+				// modify nhc to select control plane nodes
+				nhc.Spec.Selector = metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      commonlabels.ControlPlaneRole,
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				}
+				nodeUnderTest = utils.GetControlPlaneNode(k8sClient)
+			})
+
+			It("Remediates the control plane node", func() {
+				By("making node unhealthy")
+				nodeUnhealthyTime := utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
+
+				By("ensuring remediation CR exists")
+				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
+				// for control plane remediation we need to wait longer, because NHC might need to change leader / restart the pod
+				waitTime += 6 * time.Minute
+				Eventually(
+					fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), waitTime, "1s").
+					Should(Succeed())
+
+				By("ensuring status is set")
+				Eventually(func(g Gomega) {
+					nhc = getNodeHealthCheck()
+					g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
+					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
+					g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
+					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
+				}, "10s", "500ms").Should(Succeed())
+
+				By("waiting for healthy node condition")
+				utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
+
+				By("waiting for remediation CR deletion, else cleanup fails")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
+					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
+				}, "5m", "5s").Should(Succeed(), "CR not deleted")
+			})
+		}) // end of control plane node context
 
 	}) // end of remediation context
 })

--- a/e2e/nhc_e2e_test.go
+++ b/e2e/nhc_e2e_test.go
@@ -15,17 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
-	"github.com/medik8s/node-healthcheck-operator/controllers/console"
 	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
 	"github.com/medik8s/node-healthcheck-operator/e2e/utils"
 )
@@ -34,10 +30,7 @@ const (
 	nhcName = "test-nhc"
 )
 
-var _ = Describe("e2e", Label("NHC"), func() {
-	var nodeUnderTest *v1.Node
-	var node2 *v1.Node
-	var node3 *v1.Node
+var _ = Describe("e2e - NHC", Label("NHC"), func() {
 	var nhc *v1alpha1.NodeHealthCheck
 
 	BeforeEach(func() {
@@ -82,20 +75,6 @@ var _ = Describe("e2e", Label("NHC"), func() {
 				},
 			},
 		}
-
-		if nodeUnderTest == nil {
-			// find a worker node
-			workers := &v1.NodeList{}
-			selector := labels.NewSelector()
-			reqCpRole, _ := labels.NewRequirement(commonlabels.ControlPlaneRole, selection.DoesNotExist, []string{})
-			reqMRole, _ := labels.NewRequirement(commonlabels.MasterRole, selection.DoesNotExist, []string{})
-			selector = selector.Add(*reqCpRole, *reqMRole)
-			Expect(k8sClient.List(context.Background(), workers, &ctrl.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
-			Expect(len(workers.Items)).To(BeNumerically(">=", 3))
-			nodeUnderTest = &workers.Items[0]
-			node2 = &workers.Items[1]
-			node3 = &workers.Items[2]
-		}
 	})
 
 	JustBeforeEach(func() {
@@ -115,29 +94,8 @@ var _ = Describe("e2e", Label("NHC"), func() {
 		})
 	})
 
-	When("when the operator and the console plugin is deployed", labelOcpOnly, func() {
-		It("the plugin manifest should be served", func() {
-			By("getting the ConsolePlugin")
-			plugin := &consolev1alpha1.ConsolePlugin{}
-			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: console.PluginName}, plugin)).To(Succeed(), "failed to get ConsolePlugin")
-
-			By("getting the plugin Service")
-			svc := &v1.Service{}
-			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Namespace: plugin.Spec.Service.Namespace, Name: plugin.Spec.Service.Name}, svc)).To(Succeed(), "failed to get plugin Service")
-
-			By("getting the console manifest")
-			manifestUrl := fmt.Sprintf("https://%s:%d/%s/plugin-manifest.json", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port, plugin.Spec.Service.BasePath)
-			cmd := fmt.Sprintf("curl -k %s", manifestUrl)
-			output, err := utils.RunCommandInCluster(clientSet, nodeUnderTest.Name, testNsName, cmd, log)
-			Expect(err).ToNot(HaveOccurred())
-			log.Info("got manifest (stripped)", "manifest", output[:100])
-			Expect(output).To(ContainSubstring(console.PluginName), "failed to get correct plugin manifest")
-		})
-	})
-
-	Context("with custom MHC", labelOcpOnly, func() {
-		It("should report disabled and re-enabled NHC", func() {
-			By("creating a MHC")
+	Context("With custom MHC", labelOcpOnly, func() {
+		BeforeEach(func() {
 			mhc := &v1beta1.MachineHealthCheck{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -156,250 +114,267 @@ var _ = Describe("e2e", Label("NHC"), func() {
 				},
 			}
 			Expect(k8sClient.Create(context.Background(), mhc)).To(Succeed(), "failed to create MHC")
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(context.Background(), mhc)).To(Succeed(), "failed to delete MHC")
+				By("waiting for NHC to be re-enabled")
+				Eventually(func(g Gomega) {
+					nhc = getNodeHealthCheck()
+					g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
+					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
+				}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
+			})
+		})
 
+		It("should report disabled NHC", func() {
 			By("waiting for NHC to be disabled")
 			Eventually(func(g Gomega) {
 				nhc = getNodeHealthCheck()
 				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeTrue(), "disabled condition should be true")
 				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseDisabled), "phase should be Disabled")
 			}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be disabled because of custom MHC")
-
-			By("deleting the MHC")
-			Expect(k8sClient.Delete(context.Background(), mhc)).To(Succeed(), "failed to delete MHC")
-
-			By("waiting for NHC to be re-enabled")
-			Eventually(func(g Gomega) {
-				nhc = getNodeHealthCheck()
-				g.Expect(meta.IsStatusConditionTrue(nhc.Status.Conditions, v1alpha1.ConditionTypeDisabled)).To(BeFalse(), "disabled condition should be false")
-				g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseEnabled), "phase should be Enabled")
-			}, 3*time.Second, 1*time.Second).Should(Succeed(), "NHC should be enabled after MHC deletion")
 		})
-	})
+	}) // end of custom MHC context
 
-	When("Node conditions meets the unhealthy criteria", func() {
+	Context("Remediation", func() {
+		var nodeUnderTest *v1.Node
 
-		Context("with escalating remediation config", labelOcpOnly, func() {
-
-			var (
-				escTimeout        metav1.Duration
-				nodeUnhealthyTime time.Time
-				//lease params
-				leaseNs   = "medik8s-leases"
-				leaseName string
-				lease     *coordv1.Lease
-			)
+		Context("Worker node with unhealthy condition", func() {
+			var node2 *v1.Node
+			var node3 *v1.Node
 
 			BeforeEach(func() {
-				escTimeout = metav1.Duration{Duration: 1 * time.Minute}
-				leaseName = fmt.Sprintf("%s-%s", "node", nodeUnderTest.Name)
-				lease = &coordv1.Lease{}
-
-				// modify nhc to use escalating remediations
-				nhc.Spec.RemediationTemplate = nil
-				nhc.Spec.EscalatingRemediations = []v1alpha1.EscalatingRemediation{
-					{
-						RemediationTemplate: v1.ObjectReference{
-							Kind:       dummyRemediationTemplateGVK.Kind,
-							APIVersion: dummyRemediationTemplateGVK.GroupVersion().String(),
-							Name:       dummyTemplateName,
-							Namespace:  testNsName,
-						},
-						Order:   0,
-						Timeout: escTimeout,
-					},
-					{
-						RemediationTemplate: v1.ObjectReference{
-							Kind:       "SelfNodeRemediationTemplate",
-							APIVersion: "self-node-remediation.medik8s.io/v1alpha1",
-							Name:       snrTemplateName,
-							Namespace:  operatorNsName,
-						},
-						Order:   5,
-						Timeout: escTimeout,
-					},
+				if nodeUnderTest == nil {
+					workers := utils.GetWorkerNodes(k8sClient)
+					nodeUnderTest = &workers[0]
+					node2 = &workers[1]
+					node3 = &workers[2]
 				}
 			})
 
-			It("Remediates a host", func() {
-				By("making node unhealthy")
-				nodeUnhealthyTime = utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
+			Context("with escalating remediation config", labelOcpOnly, func() {
 
-				By("ensuring 1st remediation CR exists")
-				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
-				Eventually(
-					fetchRemediationResourceByName(nodeUnderTest.Name,
-						testNsName,
-						schema.GroupVersionResource{
-							Group:    dummyRemediationGVK.Group,
-							Version:  dummyRemediationGVK.Version,
-							Resource: strings.ToLower(dummyRemediationGVK.Kind) + "s",
+				var (
+					escTimeout        metav1.Duration
+					nodeUnhealthyTime time.Time
+					//lease params
+					leaseNs   = "medik8s-leases"
+					leaseName string
+					lease     *coordv1.Lease
+				)
+
+				BeforeEach(func() {
+					escTimeout = metav1.Duration{Duration: 1 * time.Minute}
+					leaseName = fmt.Sprintf("%s-%s", "node", nodeUnderTest.Name)
+					lease = &coordv1.Lease{}
+
+					// modify nhc to use escalating remediations
+					nhc.Spec.RemediationTemplate = nil
+					nhc.Spec.EscalatingRemediations = []v1alpha1.EscalatingRemediation{
+						{
+							RemediationTemplate: v1.ObjectReference{
+								Kind:       dummyRemediationTemplateGVK.Kind,
+								APIVersion: dummyRemediationTemplateGVK.GroupVersion().String(),
+								Name:       dummyTemplateName,
+								Namespace:  testNsName,
+							},
+							Order:   0,
+							Timeout: escTimeout,
 						},
-					), waitTime, 1*time.Second).
-					Should(Succeed())
-
-				By("ensuring lease exist")
-				err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
-				Expect(err).ToNot(HaveOccurred())
-
-				// SNR is very fast on kind, so use a short poll intervals, otherwise node might already be healthy again
-
-				By("waiting and checking 1st remediation timed out")
-				// sleep for most of the configured timeout
-				time.Sleep(escTimeout.Duration - 2*time.Second)
-				var nhc *v1alpha1.NodeHealthCheck
-				Eventually(func(g Gomega) *metav1.Time {
-					nhc = getNodeHealthCheck()
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1), "expected unhealthy node!")
-					log.Info("checking timeout", "node", nhc.Status.UnhealthyNodes[0].Name, "remediation kind", nhc.Status.UnhealthyNodes[0].Remediations[0].Resource.Kind, "timedOut", nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut)
-					return nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut
-				}, "5s", "500ms").ShouldNot(BeNil(), "1st remediation should have timed out")
-
-				By("ensuring 2nd remediation CR exists")
-				Eventually(
-					fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), "2s", "500ms").
-					Should(Succeed())
-
-				By("ensuring status is set")
-				Eventually(func(g Gomega) {
-					nhc = getNodeHealthCheck()
-					g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
-					g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(2))
-					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
-				}, "2s", "500ms").Should(Succeed())
-
-				By("waiting for healthy node")
-				utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
-
-				By("ensuring lease is removed")
-				Eventually(
-					func() bool {
-						err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
-						return errors.IsNotFound(err)
-					}, 5*time.Minute, 5*time.Second).
-					Should(BeTrue())
-
-				By("waiting for remediation CR deletion, else cleanup fails")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
-				}, "5m", "5s").Should(Succeed(), "CR not deleted")
-
-			})
-		})
-
-		Context("with classic remediation config", func() {
-
-			var nodeUnhealthyTime time.Time
-
-			BeforeEach(func() {
-				nodeUnderTest = node2
-			})
-
-			It("Remediates a host and prevents config updates", func() {
-				By("making node unhealthy")
-				nodeUnhealthyTime = utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
-
-				By("ensuring remediation CR exists")
-				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
-				Eventually(
-					fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), waitTime, "500ms").
-					Should(Succeed())
-
-				By("ensuring status is set")
-				Eventually(func(g Gomega) {
-					nhc = getNodeHealthCheck()
-					g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
-					g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
-					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
-				}, "10s", "500ms").Should(Succeed())
-
-				// let's do some NHC validation tests here
-				By("ensuring negative minHealthy update fails")
-				nhc = getNodeHealthCheck()
-				negValue := intstr.FromInt(-1)
-				nhc.Spec.MinHealthy = &negValue
-				Expect(k8sClient.Update(context.Background(), nhc)).To(MatchError(ContainSubstring("MinHealthy")), "negative minHealthy update should be prevented")
-
-				By("ensuring selector update fails")
-				nhc = getNodeHealthCheck()
-				nhc.Spec.Selector = metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"foo": "bar",
-					},
-				}
-				Expect(k8sClient.Update(context.Background(), nhc)).To(MatchError(ContainSubstring(v1alpha1.OngoingRemediationError)), "selector update should be prevented")
-
-				By("ensuring config deletion fails")
-				nhc = getNodeHealthCheck()
-				Expect(k8sClient.Delete(context.Background(), nhc)).To(MatchError(ContainSubstring(v1alpha1.OngoingRemediationError)), "deletion should be prevented")
-
-				By("ensuring minHealthy update succeeds")
-				nhc = getNodeHealthCheck()
-				newValue := intstr.FromString("10%")
-				nhc.Spec.MinHealthy = &newValue
-				Expect(k8sClient.Update(context.Background(), nhc)).To(Succeed(), "minHealthy update should be allowed")
-
-				By("waiting for healthy node condition")
-				utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
-
-				By("waiting for remediation CR deletion, else cleanup fails")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
-				}, "5m", "5s").Should(Succeed(), "CR not deleted")
-			})
-		})
-
-		// Run this as last one, since the node won't be remediated!
-		Context("with terminating node", labelOcpOnly, func() {
-
-			BeforeEach(func() {
-				nodeUnderTest = node3
-				Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
-				conditions := nodeUnderTest.Status.Conditions
-				conditions = append(conditions, v1.NodeCondition{
-					Type:   mhc.NodeConditionTerminating,
-					Status: "True",
-				})
-				nodeUnderTest.Status.Conditions = conditions
-				Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
-
-				utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
-			})
-
-			AfterEach(func() {
-				Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
-				conditions := nodeUnderTest.Status.Conditions
-				for i, cond := range conditions {
-					if cond.Type == mhc.NodeConditionTerminating {
-						conditions = append(conditions[:i], conditions[i+1:]...)
-						break
+						{
+							RemediationTemplate: v1.ObjectReference{
+								Kind:       "SelfNodeRemediationTemplate",
+								APIVersion: "self-node-remediation.medik8s.io/v1alpha1",
+								Name:       snrTemplateName,
+								Namespace:  operatorNsName,
+							},
+							Order:   5,
+							Timeout: escTimeout,
+						},
 					}
-				}
-				nodeUnderTest.Status.Conditions = conditions
-				Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
+				})
 
-				// now it should remediate, wait until the node is healthy for cleaning up!
-				By("waiting for healthy node condition")
-				utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
+				It("Remediates a host", func() {
+					By("making node unhealthy")
+					nodeUnhealthyTime = utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
 
-				By("waiting for remediation CR deletion, else cleanup fails")
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
-					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
-				}, "5m", "5s").Should(Succeed(), "CR not deleted")
-			})
+					By("ensuring 1st remediation CR exists")
+					waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
+					Eventually(
+						fetchRemediationResourceByName(nodeUnderTest.Name,
+							testNsName,
+							schema.GroupVersionResource{
+								Group:    dummyRemediationGVK.Group,
+								Version:  dummyRemediationGVK.Version,
+								Resource: strings.ToLower(dummyRemediationGVK.Kind) + "s",
+							},
+						), waitTime, 1*time.Second).
+						Should(Succeed())
 
-			It("should not remediate", func() {
-				Consistently(
-					fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), unhealthyConditionDuration+60*time.Second, 10*time.Second).
-					ShouldNot(Succeed())
-			})
-		})
+					By("ensuring lease exist")
+					err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
+					Expect(err).ToNot(HaveOccurred())
 
-	})
+					// SNR is very fast on kind, so use a short poll intervals, otherwise node might already be healthy again
+
+					By("waiting and checking 1st remediation timed out")
+					// sleep for most of the configured timeout
+					time.Sleep(escTimeout.Duration - 2*time.Second)
+					var nhc *v1alpha1.NodeHealthCheck
+					Eventually(func(g Gomega) *metav1.Time {
+						nhc = getNodeHealthCheck()
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1), "expected unhealthy node!")
+						log.Info("checking timeout", "node", nhc.Status.UnhealthyNodes[0].Name, "remediation kind", nhc.Status.UnhealthyNodes[0].Remediations[0].Resource.Kind, "timedOut", nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut)
+						return nhc.Status.UnhealthyNodes[0].Remediations[0].TimedOut
+					}, "5s", "500ms").ShouldNot(BeNil(), "1st remediation should have timed out")
+
+					By("ensuring 2nd remediation CR exists")
+					Eventually(
+						fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), "2s", "500ms").
+						Should(Succeed())
+
+					By("ensuring status is set")
+					Eventually(func(g Gomega) {
+						nhc = getNodeHealthCheck()
+						g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
+						g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(2))
+						g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
+					}, "2s", "500ms").Should(Succeed())
+
+					By("waiting for healthy node")
+					utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
+
+					By("ensuring lease is removed")
+					Eventually(
+						func() bool {
+							err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
+							return errors.IsNotFound(err)
+						}, 5*time.Minute, 5*time.Second).
+						Should(BeTrue())
+
+					By("waiting for remediation CR deletion, else cleanup fails")
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
+					}, "5m", "5s").Should(Succeed(), "CR not deleted")
+
+				})
+			}) // end of escalating remediation context
+
+			Context("with classic remediation config", func() {
+
+				var nodeUnhealthyTime time.Time
+
+				BeforeEach(func() {
+					nodeUnderTest = node2
+				})
+
+				It("Remediates a host and prevents config updates", func() {
+					By("making node unhealthy")
+					nodeUnhealthyTime = utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
+
+					By("ensuring remediation CR exists")
+					waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
+					Eventually(
+						fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), waitTime, "500ms").
+						Should(Succeed())
+
+					By("ensuring status is set")
+					Eventually(func(g Gomega) {
+						nhc = getNodeHealthCheck()
+						g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
+						g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
+						g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
+					}, "10s", "500ms").Should(Succeed())
+
+					// let's do some NHC validation tests here
+					By("ensuring negative minHealthy update fails")
+					nhc = getNodeHealthCheck()
+					negValue := intstr.FromInt(-1)
+					nhc.Spec.MinHealthy = &negValue
+					Expect(k8sClient.Update(context.Background(), nhc)).To(MatchError(ContainSubstring("MinHealthy")), "negative minHealthy update should be prevented")
+
+					By("ensuring selector update fails")
+					nhc = getNodeHealthCheck()
+					nhc.Spec.Selector = metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					}
+					Expect(k8sClient.Update(context.Background(), nhc)).To(MatchError(ContainSubstring(v1alpha1.OngoingRemediationError)), "selector update should be prevented")
+
+					By("ensuring config deletion fails")
+					nhc = getNodeHealthCheck()
+					Expect(k8sClient.Delete(context.Background(), nhc)).To(MatchError(ContainSubstring(v1alpha1.OngoingRemediationError)), "deletion should be prevented")
+
+					By("ensuring minHealthy update succeeds")
+					nhc = getNodeHealthCheck()
+					newValue := intstr.FromString("10%")
+					nhc.Spec.MinHealthy = &newValue
+					Expect(k8sClient.Update(context.Background(), nhc)).To(Succeed(), "minHealthy update should be allowed")
+
+					By("waiting for healthy node condition")
+					utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
+
+					By("waiting for remediation CR deletion, else cleanup fails")
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
+					}, "5m", "5s").Should(Succeed(), "CR not deleted")
+				})
+			}) // end of classic remediation context
+
+			// Run this as last one, since the node won't be remediated!
+			Context("with terminating node", labelOcpOnly, func() {
+
+				BeforeEach(func() {
+					nodeUnderTest = node3
+					Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
+					conditions := nodeUnderTest.Status.Conditions
+					conditions = append(conditions, v1.NodeCondition{
+						Type:   mhc.NodeConditionTerminating,
+						Status: "True",
+					})
+					nodeUnderTest.Status.Conditions = conditions
+					Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
+
+					utils.MakeNodeUnready(k8sClient, clientSet, nodeUnderTest, testNsName, log)
+				})
+
+				AfterEach(func() {
+					Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nodeUnderTest), nodeUnderTest)).To(Succeed())
+					conditions := nodeUnderTest.Status.Conditions
+					for i, cond := range conditions {
+						if cond.Type == mhc.NodeConditionTerminating {
+							conditions = append(conditions[:i], conditions[i+1:]...)
+							break
+						}
+					}
+					nodeUnderTest.Status.Conditions = conditions
+					Expect(k8sClient.Status().Update(context.Background(), nodeUnderTest)).To(Succeed())
+
+					// now it should remediate, wait until the node is healthy for cleaning up!
+					By("waiting for healthy node condition")
+					utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
+
+					By("waiting for remediation CR deletion, else cleanup fails")
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(nhc), nhc)).To(Succeed())
+						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(0))
+					}, "5m", "5s").Should(Succeed(), "CR not deleted")
+				})
+
+				It("should not remediate", func() {
+					Consistently(
+						fetchRemediationResourceByName(nodeUnderTest.Name, operatorNsName, remediationGVR), unhealthyConditionDuration+60*time.Second, 10*time.Second).
+						ShouldNot(Succeed())
+				})
+			}) // end of terminating node context
+
+		}) // end of worker node context
+
+	}) // end of remediation context
 })
 
 func getNodeHealthCheck() *v1alpha1.NodeHealthCheck {

--- a/e2e/utils/node.go
+++ b/e2e/utils/node.go
@@ -6,9 +6,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	commonlabels "github.com/medik8s/common/pkg/labels"
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -54,4 +57,25 @@ func WaitForNodeHealthyCondition(k8sClient ctrl.Client, node *v1.Node, status v1
 		return v1.ConditionStatus("failure")
 	}, nodeRebootedTimeout, 1*time.Second).Should(Equal(status))
 	return transitionTime
+}
+
+func GetWorkerNodes(k8sClient ctrl.Client) []v1.Node {
+	workers := &v1.NodeList{}
+	selector := labels.NewSelector()
+	reqCpRole, _ := labels.NewRequirement(commonlabels.ControlPlaneRole, selection.DoesNotExist, []string{})
+	reqMRole, _ := labels.NewRequirement(commonlabels.MasterRole, selection.DoesNotExist, []string{})
+	selector = selector.Add(*reqCpRole, *reqMRole)
+	Expect(k8sClient.List(context.Background(), workers, &ctrl.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
+	Expect(len(workers.Items)).To(BeNumerically(">=", 3))
+	return workers.Items
+}
+
+func GetControlPlaneNode(k8sClient ctrl.Client) *v1.Node {
+	cpNodes := &v1.NodeList{}
+	selector := labels.NewSelector()
+	reqCpRole, _ := labels.NewRequirement(commonlabels.ControlPlaneRole, selection.Exists, []string{})
+	selector = selector.Add(*reqCpRole)
+	Expect(k8sClient.List(context.Background(), cpNodes, &ctrl.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
+	Expect(len(cpNodes.Items)).To(BeNumerically(">=", 3))
+	return &cpNodes.Items[0]
 }

--- a/e2e/utils/node.go
+++ b/e2e/utils/node.go
@@ -46,8 +46,8 @@ func modifyKubelet(clientSet *kubernetes.Clientset, node *v1.Node, namespace str
 
 func WaitForNodeHealthyCondition(k8sClient ctrl.Client, node *v1.Node, status v1.ConditionStatus) time.Time {
 	var transitionTime time.Time
-	Eventually(func() v1.ConditionStatus {
-		Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(node), node)).To(Succeed())
+	Eventually(func(g Gomega) v1.ConditionStatus {
+		g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(node), node)).To(Succeed())
 		for _, cond := range node.Status.Conditions {
 			if cond.Type == v1.NodeReady {
 				transitionTime = cond.LastTransitionTime.Time


### PR DESCRIPTION
When the PDB doesn't allow disruptions, we need to check if the unhealthy node is already disrupted. If so, remediation is allowed.

Fix for #272
[ECOPROJECT-1003](https://issues.redhat.com//browse/ECOPROJECT-1003)
[ECOPROJECT-1806](https://issues.redhat.com//browse/ECOPROJECT-1806)

Note for reviewers: probably makes sense to review the commits separately, because one is reorganizing e2e test, while the next one adds the new test