### PR TITLE
Fix ongoing remediation check in webhook

### DIFF
--- a/api/v1alpha1/nodehealthcheck_webhook.go
+++ b/api/v1alpha1/nodehealthcheck_webhook.go
@@ -194,5 +194,10 @@ func (nhc *NodeHealthCheck) isRestrictedFieldUpdated(old *NodeHealthCheck) (bool
 }
 
 func (nhc *NodeHealthCheck) isRemediating() bool {
-	return len(nhc.Status.InFlightRemediations) > 0 || len(nhc.Status.UnhealthyNodes) > 0
+	for _, unhealthyNode := range nhc.Status.UnhealthyNodes {
+		if len(unhealthyNode.Remediations) > 0 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Only consider NHC as remediating when the unhealthy node actually has a remediation

[ECOPROJECT-1817](https://issues.redhat.com//browse/ECOPROJECT-1817)