### PR TITLE
Watch templates for updating NHC status

### DIFF
--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -26,6 +26,7 @@ import (
 type Manager interface {
 	GetCurrentTemplateWithTimeout(node *corev1.Node, nhc *remediationv1alpha1.NodeHealthCheck) (*unstructured.Unstructured, *time.Duration, error)
 	GetTemplate(mhc *machinev1beta1.MachineHealthCheck) (*unstructured.Unstructured, error)
+	GenerateTemplate(reference *corev1.ObjectReference) *unstructured.Unstructured
 	ValidateTemplates(nhc *remediationv1alpha1.NodeHealthCheck) (valid bool, reason string, message string, err error)
 	GenerateRemediationCRBase(gvk schema.GroupVersionKind) *unstructured.Unstructured
 	GenerateRemediationCRBaseNamed(gvk schema.GroupVersionKind, namespace string, name string) *unstructured.Unstructured

--- a/controllers/resources/templates.go
+++ b/controllers/resources/templates.go
@@ -80,10 +80,7 @@ func (m *manager) getTemplate(templateRef *v1.ObjectReference) (*unstructured.Un
 }
 
 func (m *manager) getTemplateWithFallbackNamespace(templateRef *v1.ObjectReference, crNamespace string) (*unstructured.Unstructured, error) {
-	template := new(unstructured.Unstructured)
-	template.SetGroupVersionKind(templateRef.GroupVersionKind())
-	template.SetName(templateRef.Name)
-	template.SetNamespace(templateRef.Namespace)
+	template := m.GenerateTemplate(templateRef)
 
 	// ensure namespace is set if needed
 	if isNamespaced, err := m.IsObjectNamespaced(template); err != nil {
@@ -106,6 +103,14 @@ func (m *manager) getTemplateWithFallbackNamespace(templateRef *v1.ObjectReferen
 		return nil, brokenTemplateError{fmt.Sprintf("invalid template %s/%s, didn't find spec.template.spec", template.GetNamespace(), template.GetName())}
 	}
 	return template, nil
+}
+
+func (m *manager) GenerateTemplate(templateRef *v1.ObjectReference) *unstructured.Unstructured {
+	template := new(unstructured.Unstructured)
+	template.SetGroupVersionKind(templateRef.GroupVersionKind())
+	template.SetName(templateRef.Name)
+	template.SetNamespace(templateRef.Namespace)
+	return template
 }
 
 // ValidateTemplates only returns an error when we don't know whether the template is valid or not, for triggering a requeue with backoff

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -81,6 +81,8 @@ var (
 		Namespace:  MachineNamespace,
 		Name:       InfraRemediationTemplateName,
 	}
+
+	infraRemediationTemplate *unstructured.Unstructured
 )
 
 var cfg *rest.Config
@@ -151,7 +153,8 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient.Create(context.Background(), newTestRemediationTemplateCRD(InfraRemediationKind))).To(Succeed())
 	Expect(k8sClient.Create(context.Background(), newTestRemediationCRD(InfraRemediationKind))).To(Succeed())
 	time.Sleep(time.Second)
-	Expect(k8sClient.Create(context.Background(), newTestRemediationTemplateCR(InfraRemediationKind, MachineNamespace, InfraRemediationTemplateName))).To(Succeed())
+	infraRemediationTemplate = newTestRemediationTemplateCR(InfraRemediationKind, MachineNamespace, InfraRemediationTemplateName)
+	Expect(k8sClient.Create(context.Background(), infraRemediationTemplate)).To(Succeed())
 
 	testKind := "Metal3Remediation"
 	Expect(k8sClient.Create(context.Background(), newTestRemediationTemplateCRD(testKind))).To(Succeed())


### PR DESCRIPTION
- refactor adding watches to do it once at the beginning of reconcile
- also add watches for templates, in order to update NHC status when e.g a template is deleted

[ECOPROJECT-1845](https://issues.redhat.com//browse/ECOPROJECT-1845)