### PR TITLE
Fix control plane check

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -513,9 +513,9 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 		if isAllowed, err := r.isControlPlaneRemediationAllowed(ctx, node, nhc, rm); err != nil {
 			return nil, errors.Wrapf(err, "failed to check if control plane remediation is allowed")
 		} else if !isAllowed {
-			log.Info("skipping remediation for preventing control plane / etcd quorum loss", "node", node.GetName())
-			commonevents.WarningEventf(r.Recorder, nhc, utils.EventReasonRemediationSkipped, "Skipping remediation of %s for preventing control plane / etcd quorum loss", node.GetName())
-			return nil, nil
+			log.Info("skipping remediation for preventing control plane / etcd quorum loss, going to retry in a minute", "node", node.GetName())
+			commonevents.WarningEventf(r.Recorder, nhc, utils.EventReasonRemediationSkipped, "Skipping remediation of %s for preventing control plane / etcd quorum loss, going to retry in a minute", node.GetName())
+			return pointer.Duration(1 * time.Minute), nil
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/go-logr/logr v1.4.1
-	github.com/medik8s/common v1.13.0
+	github.com/medik8s/common v1.15.1
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
 	github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e // release-4.16

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/medik8s/common v1.13.0 h1:M6R2DjJt5dB1uNGPrGxPBiJj9CX0FESUbMm0G04Q3iQ=
-github.com/medik8s/common v1.13.0/go.mod h1:Dfbu7aAj4NcYeUPA7BYzcK/JwT+QeU4GlZcJ/p+hXQY=
+github.com/medik8s/common v1.15.1 h1:qo2FBZGSegf5q35AZlWzrmgwW1GfUPNmmWaPhb/Uurc=
+github.com/medik8s/common v1.15.1/go.mod h1:A9jYldC6PZcAuBowNNm712FqWdASB2ey5Vjp8MYN/PY=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/vendor/github.com/medik8s/common/pkg/events/events.go
+++ b/vendor/github.com/medik8s/common/pkg/events/events.go
@@ -35,17 +35,22 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // Special case events
 
-// RemediationStarted will record a Normal event with reason RemediationStarted and message Remediation started.
+// RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
 }
 
-// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped.
+// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
 }
 
-// RemediationFinished will record a Normal event with reason RemediationFinished and message Remediation finished.
+// RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+}
+
+// GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
+func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
+	WarningEvent(recorder, object, "RemediationCannotStart", "Could not get remediation target Node")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0
 ## explicit; go 1.19
 github.com/matttproud/golang_protobuf_extensions/v2/pbutil
-# github.com/medik8s/common v1.13.0
+# github.com/medik8s/common v1.15.1
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/annotations
 github.com/medik8s/common/pkg/conditions


### PR DESCRIPTION
- retry after a minute when cp node remediation isn't allowed (etcd status might change)
- consider nodes with guard pods without ready condition as disrupted (in common update)

[ECOPROJECT-1882](https://issues.redhat.com//browse/ECOPROJECT-1882)