### PR TITLE
Fix install of latest Go z version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
+# use latest Go z release
+ENV GOTOOLCHAIN=auto
+
 # Ensure correct Go version
 RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
     go get go@${GO_VERSION} && \


### PR DESCRIPTION
#### Why we need this PR
Image build fails with `go: updating go.mod requires go >= 1.21.8 (running go 1.21.7; GOTOOLCHAIN=local)`

#### Changes made
Set `GOTOOLCHAIN=auto` as env var in the Dockerfile

#### Which issue(s) this PR fixes
None

#### Test plan
Not needed, successful build and e2e tests is prove enough :) 