### PR TITLE
Don't use `replaces` field for k8s release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,9 @@ on:
      version:
        description: "The version to release, without the leading `v`"
        required: true
-     previous_version:
-       description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
-       required: true
+     #previous_version:
+     #  description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
+     #  required: true
      skip_range_lower:
        description: "Lower bound for the skipRange field in the CSV, should be set to the oldest supported version, without the leading `v`"
        required: true
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       VERSION: ${{ inputs.version }}
-      PREVIOUS_VERSION: ${{ inputs.previous_version }}
+      #PREVIOUS_VERSION: ${{ inputs.previous_version }}
       SKIP_RANGE_LOWER: ${{ inputs.skip_range_lower }}
     steps:
       - name: Log inputs
         run: |
           echo "Building version: ${VERSION},"
-          echo "which replaces version: ${PREVIOUS_VERSION}."
+          #echo "which replaces version: ${PREVIOUS_VERSION}."
           echo "Lower skip range bound: ${SKIP_RANGE_LOWER}."
 
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, th
 			echo "Error: PREVIOUS_VERSION must be set for versioned builds"; \
 			exit 1; \
 		else \
-		  	# preferring sed here, in order to have "replaces" near "version"
+		  	# preferring sed here, in order to have "replaces" near "version" \
 			sed -r -i "/  version: $(VERSION)/ a\  replaces: $(OPERATOR_NAME).v$(PREVIOUS_VERSION)" ${CSV}; \
 		fi \
 	fi


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
Community hubs reject replaces field when using semver as update strategy

#### Changes made
Removed replaces field from generic make target to ocp only

#### Test plan
see success after removing field in https://github.com/k8s-operatorhub/community-operators/pull/3982