### PR TITLE
Ensure MachineAPI is enabled before trying to use its resources

### DIFF
--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 
 	v1 "github.com/openshift/api/config/v1"
@@ -13,11 +15,47 @@ import (
 )
 
 type Capabilities struct {
-	HasEtcdPDBQuorum, HasMachineAPI bool
+	IsOnOpenshift, HasMachineAPI bool
+}
+
+func NewCapabilities(config *rest.Config) (Capabilities, error) {
+	var err error
+	var onOpenshift, machineAPI bool
+
+	if onOpenshift, err = isOnOpenshift(config); err != nil {
+		return Capabilities{}, errors.Wrap(err, "failed to check if cluster is on OpenShift")
+	} else if onOpenshift {
+		if machineAPI, err = hasMachineAPICapability(config); err != nil {
+			return Capabilities{}, errors.Wrap(err, "failed to check machine API capability")
+		}
+	}
+
+	return Capabilities{
+		IsOnOpenshift: onOpenshift,
+		HasMachineAPI: machineAPI,
+	}, nil
+}
+
+// IsOnOpenshift returns true if the cluster has the openshift config group
+func isOnOpenshift(config *rest.Config) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	apiGroups, err := dc.ServerGroups()
+	kind := schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "ClusterVersion"}
+	for _, apiGroup := range apiGroups.Groups {
+		for _, supportedVersion := range apiGroup.Versions {
+			if supportedVersion.GroupVersion == kind.GroupVersion().String() {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // HasMachineAPICapability returns true if the cluster has the MachineAPI Enabled
-func HasMachineAPICapability(config *rest.Config) (bool, error) {
+func hasMachineAPICapability(config *rest.Config) (bool, error) {
 	configV1Client, err := configv1.NewForConfig(config)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to create cluster version client")

--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -1,0 +1,42 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+)
+
+type Capabilities struct {
+	HasEtcdPDBQuorum, HasMachineAPI bool
+}
+
+// HasMachineAPICapability returns true if the cluster has the MachineAPI Enabled
+func HasMachineAPICapability(config *rest.Config) (bool, error) {
+	configV1Client, err := configv1.NewForConfig(config)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to create cluster version client")
+	}
+	cvs, err := configV1Client.ClusterVersions().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get ClusterVersion")
+	}
+
+	for _, cv := range cvs.Items {
+		if cv.Status.Capabilities.EnabledCapabilities == nil {
+			return false, nil
+		}
+		var MachineAPI v1.ClusterVersionCapability = "MachineAPI"
+		for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
+			if capability == MachineAPI {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/controllers/cluster/upgrade_checker.go
+++ b/controllers/cluster/upgrade_checker.go
@@ -13,8 +13,6 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	clusterversion "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-
-	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
 )
 
 var unsupportedUpgradeCheckerErr = errors.New(
@@ -66,12 +64,8 @@ func (n *noopClusterUpgradeStatusChecker) Check() (bool, error) {
 
 // NewClusterUpgradeStatusChecker will return some implementation of a checker or err in case it can't
 // reliably detect which implementation to use.
-func NewClusterUpgradeStatusChecker(mgr manager.Manager) (UpgradeChecker, error) {
-	openshift, err := utils.IsOnOpenshift(mgr.GetConfig())
-	if err != nil {
-		return nil, err
-	}
-	if !openshift {
+func NewClusterUpgradeStatusChecker(mgr manager.Manager, caps Capabilities) (UpgradeChecker, error) {
+	if !caps.IsOnOpenshift {
 		return &noopClusterUpgradeStatusChecker{}, nil
 	}
 	checker, err := newOpenshiftClusterUpgradeChecker(mgr)

--- a/controllers/console/plugin.go
+++ b/controllers/console/plugin.go
@@ -24,7 +24,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/api/console/v1alpha1"
@@ -47,14 +46,10 @@ const (
 // HEADS UP: consider cleanup of old resources in case of name changes or removals!
 //
 // TODO image reference to console plugin in CSV?
-func CreateOrUpdatePlugin(ctx context.Context, cl client.Client, config *rest.Config, namespace string, log logr.Logger) error {
+func CreateOrUpdatePlugin(ctx context.Context, cl client.Client, caps cluster.Capabilities, namespace string, log logr.Logger) error {
 
 	// check if we are on OCP
-	clusterCapabilities, err := cluster.NewCapabilities(config)
-	if err != nil {
-		return errors.Wrap(err, "failed to check cluster capabilities")
-	}
-	if !clusterCapabilities.IsOnOpenshift {
+	if !caps.IsOnOpenshift {
 		log.Info("we are not on Openshift, skipping console plugin activation")
 		return nil
 	}

--- a/controllers/console/plugin.go
+++ b/controllers/console/plugin.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/openshift/api/console/v1alpha1"
 
-	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 )
 
 const (
@@ -50,9 +50,11 @@ const (
 func CreateOrUpdatePlugin(ctx context.Context, cl client.Client, config *rest.Config, namespace string, log logr.Logger) error {
 
 	// check if we are on OCP
-	if isOpenshift, err := utils.IsOnOpenshift(config); err != nil {
-		return errors.Wrap(err, "failed to check if we are on Openshift")
-	} else if !isOpenshift {
+	clusterCapabilities, err := cluster.NewCapabilities(config)
+	if err != nil {
+		return errors.Wrap(err, "failed to check cluster capabilities")
+	}
+	if !clusterCapabilities.IsOnOpenshift {
 		log.Info("we are not on Openshift, skipping console plugin activation")
 		return nil
 	}

--- a/controllers/initializer/init.go
+++ b/controllers/initializer/init.go
@@ -6,10 +6,10 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 	"github.com/medik8s/node-healthcheck-operator/controllers/console"
 	"github.com/medik8s/node-healthcheck-operator/controllers/rbac"
 	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
@@ -20,17 +20,17 @@ import (
 // - create default NHC
 // - create console plugin
 type initializer struct {
-	cl     client.Client
-	config *rest.Config
-	logger logr.Logger
+	cl           client.Client
+	capabilities cluster.Capabilities
+	logger       logr.Logger
 }
 
 // New returns a new Initializer
-func New(mgr ctrl.Manager, logger logr.Logger) *initializer {
+func New(mgr ctrl.Manager, caps cluster.Capabilities, logger logr.Logger) *initializer {
 	return &initializer{
-		cl:     mgr.GetClient(),
-		config: mgr.GetConfig(),
-		logger: logger,
+		cl:           mgr.GetClient(),
+		capabilities: caps,
+		logger:       logger,
 	}
 }
 
@@ -46,7 +46,7 @@ func (i *initializer) Start(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create or update RBAC aggregation role")
 	}
 
-	if err = console.CreateOrUpdatePlugin(ctx, i.cl, i.config, ns, ctrl.Log.WithName("console-plugin")); err != nil {
+	if err = console.CreateOrUpdatePlugin(ctx, i.cl, i.capabilities, ns, ctrl.Log.WithName("console-plugin")); err != nil {
 		return errors.Wrap(err, "failed to create or update the console plugin")
 	}
 

--- a/controllers/initializer/init_test.go
+++ b/controllers/initializer/init_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 )
 
 var _ = Describe("Init", func() {
@@ -14,7 +16,8 @@ var _ = Describe("Init", func() {
 	var initializer *initializer
 
 	JustBeforeEach(func() {
-		initializer = New(k8sManager, ctrl.Log.WithName("test initializer"))
+		caps := cluster.Capabilities{IsOnOpenshift: true, HasMachineAPI: true}
+		initializer = New(k8sManager, caps, ctrl.Log.WithName("test initializer"))
 	})
 
 	AfterEach(func() {

--- a/controllers/initializer/suite_test.go
+++ b/controllers/initializer/suite_test.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	consolev1alpha "github.com/openshift/api/console/v1alpha1"
+
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 )
 
@@ -63,7 +65,13 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "vendor", "github.com", "openshift", "api", "console", "v1alpha1"),
+				filepath.Join("..", "..", "config", "crd", "bases"),
+			},
+			ErrorIfPathMissing: true,
+		},
 	}
 
 	var err error
@@ -72,8 +80,8 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	scheme.AddToScheme(scheme.Scheme)
-	err = remediationv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(remediationv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(consolev1alpha.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -33,6 +33,7 @@ import (
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 	"github.com/medik8s/node-healthcheck-operator/controllers/featuregates"
 	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
 	"github.com/medik8s/node-healthcheck-operator/controllers/resources"
@@ -2386,7 +2387,8 @@ func newFakeReconcilerWithCustomRecorder(recorder record.EventRecorder, initObje
 		WithRuntimeObjects(initObjects...).
 		WithStatusSubresource(&machinev1.MachineHealthCheck{}).
 		Build()
-	mhcChecker, _ := mhc.NewMHCChecker(k8sManager, false, nil)
+	caps := cluster.Capabilities{IsOnOpenshift: false, HasMachineAPI: false}
+	mhcChecker, _ := mhc.NewMHCChecker(k8sManager, caps, nil)
 	return &MachineHealthCheckReconciler{
 		Client:                         fakeClient,
 		Recorder:                       recorder,

--- a/controllers/mhc/checker.go
+++ b/controllers/mhc/checker.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/openshift/api/machine/v1beta1"
+
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 )
 
 // NodeConditionTerminating is the node condition type used by the termination handler MHC
@@ -25,9 +27,9 @@ type Checker interface {
 }
 
 // NewMHCChecker creates a new Checker
-func NewMHCChecker(mgr manager.Manager, hasMachineAPI bool, mhcEvents chan<- event.GenericEvent) (Checker, error) {
+func NewMHCChecker(mgr manager.Manager, caps cluster.Capabilities, mhcEvents chan<- event.GenericEvent) (Checker, error) {
 
-	if !hasMachineAPI {
+	if !caps.HasMachineAPI {
 		return DummyChecker{}, nil
 	}
 

--- a/controllers/mhc/checker.go
+++ b/controllers/mhc/checker.go
@@ -25,9 +25,9 @@ type Checker interface {
 }
 
 // NewMHCChecker creates a new Checker
-func NewMHCChecker(mgr manager.Manager, onOpenshift bool, mhcEvents chan<- event.GenericEvent) (Checker, error) {
+func NewMHCChecker(mgr manager.Manager, hasMachineAPI bool, mhcEvents chan<- event.GenericEvent) (Checker, error) {
 
-	if !onOpenshift {
+	if !hasMachineAPI {
 		return DummyChecker{}, nil
 	}
 

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -683,7 +683,8 @@ func (r *NodeHealthCheckReconciler) isControlPlaneRemediationAllowed(ctx context
 	}
 
 	// no ongoing control plane remediation, check etcd quorum
-	if !r.Capabilities.HasEtcdPDBQuorum {
+	if !r.Capabilities.IsOnOpenshift {
+		// etcd quorum PDB is only installed in OpenShift
 		return true, nil
 	}
 	var allowed bool

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -49,23 +49,23 @@ func (r RemediationCRNotOwned) Error() string { return r.msg }
 
 type manager struct {
 	client.Client
-	ctx          context.Context
-	log          logr.Logger
-	onOpenshift  bool
-	leaseManager LeaseManager
-	recorder     record.EventRecorder
+	ctx           context.Context
+	log           logr.Logger
+	hasMachineAPI bool
+	leaseManager  LeaseManager
+	recorder      record.EventRecorder
 }
 
 var _ Manager = &manager{}
 
-func NewManager(c client.Client, ctx context.Context, log logr.Logger, onOpenshift bool, leaseManager LeaseManager, recorder record.EventRecorder) Manager {
+func NewManager(c client.Client, ctx context.Context, log logr.Logger, hasMachineAPI bool, leaseManager LeaseManager, recorder record.EventRecorder) Manager {
 	return &manager{
-		Client:       c,
-		ctx:          ctx,
-		log:          log.WithName("resource manager"),
-		onOpenshift:  onOpenshift,
-		leaseManager: leaseManager,
-		recorder:     recorder,
+		Client:        c,
+		ctx:           ctx,
+		log:           log.WithName("resource manager"),
+		hasMachineAPI: hasMachineAPI,
+		leaseManager:  leaseManager,
+		recorder:      recorder,
 	}
 }
 
@@ -76,7 +76,7 @@ func (m *manager) GenerateRemediationCRForNode(node *corev1.Node, owner client.O
 	// also set the node's machine as owner ref if possible
 	// TODO also handle CAPI clusters / machines
 	var machineOwnerRef *metav1.OwnerReference
-	if m.onOpenshift {
+	if m.hasMachineAPI {
 		ref, machineNamespace, err := m.getOwningMachineWithNamespace(node)
 		if err != nil {
 			return nil, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -169,7 +169,9 @@ var _ = BeforeSuite(func() {
 		Upgrading: false,
 	}
 
-	mhcChecker, err := mhc.NewMHCChecker(k8sManager, false, nil)
+	caps := cluster.Capabilities{IsOnOpenshift: true, HasMachineAPI: true}
+
+	mhcChecker, err := mhc.NewMHCChecker(k8sManager, caps, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	os.Setenv("DEPLOYMENT_NAMESPACE", DeploymentNamespace)
@@ -197,7 +199,7 @@ var _ = BeforeSuite(func() {
 		ClusterUpgradeStatusChecker: upgradeChecker,
 		MHCChecker:                  mhcChecker,
 		MHCEvents:                   mhcEvents,
-		Capabilities:                cluster.Capabilities{HasEtcdPDBQuorum: true, HasMachineAPI: true},
+		Capabilities:                caps,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -197,7 +197,7 @@ var _ = BeforeSuite(func() {
 		ClusterUpgradeStatusChecker: upgradeChecker,
 		MHCChecker:                  mhcChecker,
 		MHCEvents:                   mhcEvents,
-		OnOpenShift:                 true,
+		Capabilities:                cluster.Capabilities{HasEtcdPDBQuorum: true, HasMachineAPI: true},
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -11,9 +11,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -43,24 +40,6 @@ func GetDeploymentNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
 	}
 	return ns, nil
-}
-
-// IsOnOpenshift returns true if the cluster has the openshift config group
-func IsOnOpenshift(config *rest.Config) (bool, error) {
-	dc, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return false, err
-	}
-	apiGroups, err := dc.ServerGroups()
-	kind := schema.GroupVersionKind{Group: "config.openshift.io", Version: "v1", Kind: "ClusterVersion"}
-	for _, apiGroup := range apiGroups.Groups {
-		for _, supportedVersion := range apiGroup.Versions {
-			if supportedVersion.GroupVersion == kind.GroupVersion().String() {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }
 
 // GetLogWithNHC return a logger with NHC namespace and name

--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	// Do some initialization
-	initializer := initializer.New(mgr, ctrl.Log.WithName("Initializer"))
+	initializer := initializer.New(mgr, caps, ctrl.Log.WithName("Initializer"))
 	if err = mgr.Add(initializer); err != nil {
 		setupLog.Error(err, "failed to add initializer to the manager")
 		os.Exit(1)


### PR DESCRIPTION
#### Why we need this PR

Currently, NHC only checks if it runs on OCP before trying to access MachineAPI resources, however not all OCP clusters have MachineAPI enabled and the controller fails to start in such conditions.


#### Changes made

Verify if MachineAPI is in the list of the Cluster's EnabledCapabilities



#### Which issue(s) this PR fixes

https://issues.redhat.com/browse/ECOPROJECT-1902

#### Todo

- [x] Fix CI tests
