### PR TITLE
Prevent overriding of pullspec set by CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ bundle-okd: ocp-version-check yq bundle-base ## Generate bundle manifests and me
 
 .PHONY: bundle-ocp
 bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, then validate generated files.
+	$(shell rm -r bundle) # OCP bundle should be created from scratch
 	$(KUSTOMIZE) build config/manifests/ocp | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	sed -r -i "s|DOCS_RHWA_VERSION|${DOCS_RHWA_VERSION}|g;" "${CSV}"
 	# Add env var with must gather image to the NHC container, so its pullspec gets added to the relatedImages section by OSBS
@@ -377,6 +378,10 @@ bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, th
 	ICON_BASE64="$(shell base64 --wrap=0 ./config/assets/nhc_red.png)" \
 		$(MAKE) bundle-update
 
+.PHONY: bundle-ocp-ci
+bundle-ocp-ci: yq ## Generate OCP bundle for CI, without overriding the image pull-spec (CI only)
+	IMG="$(shell $(YQ) -r '.metadata.annotations.containerImage' ${CSV})" \
+		$(MAKE) bundle-ocp
 
 .PHONY: bundle-k8s
 bundle-k8s: bundle-base ## Generate bundle manifests and metadata for K8s community, then validate generated files.

--- a/bundle.ci.Dockerfile
+++ b/bundle.ci.Dockerfile
@@ -12,6 +12,7 @@ COPY go.sum go.sum
 COPY PROJECT PROJECT
 COPY Makefile Makefile
 COPY config/ config/
+COPY bundle/ bundle/
 COPY hack/ hack/
 
 COPY main.go main.go
@@ -21,8 +22,8 @@ COPY controllers/ controllers/
 COPY metrics/ metrics/
 COPY vendor/ vendor/
 
-# Generate OCP bundle
-RUN make bundle-ocp
+# Generate OCP bundle without overriding the pullspec set by the CI
+RUN make bundle-ocp-ci
 
 # Build bundle image for OCP CI
 FROM scratch


### PR DESCRIPTION
#### Why we need this PR

CI is expected to set a specific pullspec for the NHC image it is
building and testing. This pullspec however was overridden by our
multistep image build in bundle.ci.Dockerfile (which in turn is
necessary to test the console-plugin, which is only contained in the OCP
bundle).

#### Changes made

This change prevents such overriding by:
- getting the current pullspec, set by CI, and
- exporting it as IMG environ variable to be used when building the
  bundle.
