### PR TITLE
Minor refactoring to test code

### DIFF
--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -815,20 +815,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 		})
 
-		Context("with Node marked for excluding remediation", func() {
-			BeforeEach(func() {
-				objects = newNodes(1, 2, false, true)
-				objects = append(objects, newNodeHealthCheck())
-				node := objects[0].(*v1.Node)
-				node.GetLabels()[commonLabels.ExcludeFromRemediation] = "true"
-
-			})
-			It("remediation shouldn't be created", func() {
-				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
-				Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
-			})
-		})
-
 		Context("with a single escalating remediation", func() {
 
 			BeforeEach(func() {
@@ -1114,6 +1100,19 @@ var _ = Describe("Node Health Check CR", func() {
 
 			})
 
+		})
+
+		Context("with Node marked for excluding remediation", func() {
+			BeforeEach(func() {
+				setupObjects(1, 2, true)
+				node := objects[0].(*v1.Node)
+				node.GetLabels()[commonLabels.ExcludeFromRemediation] = "true"
+
+			})
+			It("remediation shouldn't be created", func() {
+				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
+			})
 		})
 
 		Context("with progressing condition being set", func() {


### PR DESCRIPTION
- use `setupObjects` in order to simplify code

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
Cleaner and more readable test code.
Followup for [comment](https://github.com/medik8s/node-healthcheck-operator/pull/307#discussion_r1548038546) of #307 

#### Changes made
Modify test location and minor refactoring.


#### Which issue(s) this PR fixes
[ECOPROJECT-1844](https://issues.redhat.com//browse/ECOPROJECT-1844) 

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
