### PR TITLE
[WIP] [v2] Ensure MachineAPI is enabled before trying to use its resources

### DIFF
--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -2,6 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -14,8 +17,17 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
 
+var (
+	versionRegex = regexp.MustCompile(`(\d+)\.(\d+)`)
+)
+
 type Capabilities struct {
 	IsOnOpenshift, HasMachineAPI bool
+}
+
+type ServerVersion struct {
+	OcpVersion   string
+	Major, Minor int
 }
 
 func NewCapabilities(config *rest.Config) (Capabilities, error) {
@@ -24,8 +36,10 @@ func NewCapabilities(config *rest.Config) (Capabilities, error) {
 
 	if onOpenshift, err = isOnOpenshift(config); err != nil {
 		return Capabilities{}, errors.Wrap(err, "failed to check if cluster is on OpenShift")
-	} else if onOpenshift {
-		if machineAPI, err = hasMachineAPICapability(config); err != nil {
+	}
+
+	if onOpenshift {
+		if machineAPI, err = hasMachineAPI(config); err != nil {
 			return Capabilities{}, errors.Wrap(err, "failed to check machine API capability")
 		}
 	}
@@ -36,7 +50,7 @@ func NewCapabilities(config *rest.Config) (Capabilities, error) {
 	}, nil
 }
 
-// IsOnOpenshift returns true if the cluster has the openshift config group
+// isOnOpenshift returns true if the cluster has the openshift config group
 func isOnOpenshift(config *rest.Config) (bool, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
@@ -54,13 +68,66 @@ func isOnOpenshift(config *rest.Config) (bool, error) {
 	return false, nil
 }
 
-// HasMachineAPICapability returns true if the cluster has the MachineAPI Enabled
-func hasMachineAPICapability(config *rest.Config) (bool, error) {
-	configV1Client, err := configv1.NewForConfig(config)
+// hasMachineAPI returns true it the cluster has the MachineAPI
+func hasMachineAPI(config *rest.Config) (bool, error) {
+	client, err := configv1.NewForConfig(config)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to create cluster version client")
 	}
-	cvs, err := configV1Client.ClusterVersions().List(context.Background(), metav1.ListOptions{})
+	ocpVersion, err := getOpenshiftVersion(client)
+	if err != nil {
+		return false, errors.Wrap(err, "could not get OCP version")
+	}
+
+	if ocpVersion.Major == 4 && ocpVersion.Minor >= 14 {
+		return hasMachineAPICapability(client)
+	} else {
+		return hasMachineAPIGroup(config)
+	}
+}
+
+// getOpenshiftVersion returns the OpenShift version of the cluster
+func getOpenshiftVersion(client *configv1.ConfigV1Client) (*ServerVersion, error) {
+	clusterVersion, err := client.ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get OCP version")
+	}
+
+	var ocpVersion string
+	for _, update := range clusterVersion.Status.History {
+		if update.State == v1.CompletedUpdate {
+			// obtain the version from the last completed update
+			ocpVersion = update.Version
+			break
+		}
+	}
+	if ocpVersion == "" {
+		return nil, errors.New("could not find up to date OCP version")
+	}
+
+	matches := versionRegex.FindStringSubmatch(ocpVersion)
+	if matches == nil || len(matches) != 3 {
+		return nil, fmt.Errorf("could not get OCP version from %s (found %d matches)", ocpVersion, matches)
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get major version")
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get minor version")
+	}
+
+	return &ServerVersion{
+		OcpVersion: ocpVersion,
+		Major:      major,
+		Minor:      minor,
+	}, nil
+}
+
+// hasMachineAPICapability returns true if the cluster has the MachineAPI capability enabled
+func hasMachineAPICapability(c *configv1.ConfigV1Client) (bool, error) {
+	cvs, err := c.ClusterVersions().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to get ClusterVersion")
 	}
@@ -76,5 +143,26 @@ func hasMachineAPICapability(config *rest.Config) (bool, error) {
 			}
 		}
 	}
+
+	return false, nil
+}
+
+func hasMachineAPIGroup(c *rest.Config) (bool, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(c)
+	if err != nil {
+		return false, err
+	}
+	apiGroups, err := dc.ServerGroups()
+	group := schema.GroupVersion{Group: "machine.openshift.io", Version: "v1"}
+	for _, apiGroup := range apiGroups.Groups {
+		if apiGroup.Name == group.Group {
+			for _, supportedVersion := range apiGroup.Versions {
+				if supportedVersion.Version == group.Version {
+					return true, nil
+				}
+			}
+		}
+	}
+
 	return false, nil
 }


### PR DESCRIPTION
#### Why we need this PR

Currently, NHC only checks if it runs on OCP before trying to access MachineAPI resources, however not all OCP clusters have MachineAPI enabled and the controller fails to start in such conditions.

#### Changes made

Changes made
- Verify if MachineAPI is in the list of the Cluster's EnabledCapabilities for OCP v4.14+
- Verify the existence of machine.openshift.io Group for OCP < v.4.14


#### Which issue(s) this PR fixes

https://issues.redhat.com/browse/ECOPROJECT-1902
