### PR TITLE
leftovers from renaming container-build to container-build-ocp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ KUBECTL=oc
 endif
 
 .PHONY: all
-all: container-build container-push
+all: container-build-ocp container-push
 
 ##@ General
 
@@ -505,4 +505,4 @@ container-push:  ## Push containers (NOTE: catalog can't be build before bundle 
 	make docker-push bundle-push index-build index-push
 
 .PHONY: build-and-run
-build-and-run: container-build container-push bundle-run
+build-and-run: container-build-ocp container-push bundle-run


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
Leftover missing some renames from  PR #305

#### Changes made
<!-- Outline the specific changes made in this merge request. -->


#### Which issue(s) this PR fixes
Technical debt


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
