### PR TITLE
Do not set timeout annotation on already succeeded remediation CR

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -575,6 +575,8 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 				if timeOutErr := r.addTimeOutAnnotation(rm, remediationCR, metav1.Time{Time: now}); timeOutErr != nil {
 					return nil, timeOutErr
 				}
+			} else {
+				log.Info("skipping timeout annotation on remediation CR: Succeeded condition is True", "CR name", remediationCR.GetName())
 			}
 			startedRemediation := resources.FindStatusRemediation(node, nhc, func(r *remediationv1alpha1.Remediation) bool {
 				return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind()
@@ -656,6 +658,8 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 		if err := r.addTimeOutAnnotation(rm, remediationCR, now); err != nil {
 			return nil, err
 		}
+	} else {
+		log.Info("skipping timeout annotation on remediation CR: Succeeded condition is True", "CR name", remediationCR.GetName())
 	}
 	// update status (important to do this after CR update, else we won't retry that update in case of error)
 	startedRemediation.TimedOut = &now

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -557,8 +557,11 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 		// Lease is overdue
 		if _, isLeaseOverDue := err.(resources.LeaseOverDueError); isLeaseOverDue {
 			now := currentTime()
-			if timeOutErr := r.addTimeOutAnnotation(rm, remediationCR, metav1.Time{Time: now}); timeOutErr != nil {
-				return nil, timeOutErr
+			// add timeout annotation to remediation CR if it not Succeeded yet
+			if !remediationSucceeded(remediationCR, log) {
+				if timeOutErr := r.addTimeOutAnnotation(rm, remediationCR, metav1.Time{Time: now}); timeOutErr != nil {
+					return nil, timeOutErr
+				}
 			}
 			startedRemediation := resources.FindStatusRemediation(node, nhc, func(r *remediationv1alpha1.Remediation) bool {
 				return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind()
@@ -635,9 +638,11 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 		log.Info("remediation failed")
 	}
 
-	// add timeout annotation to remediation CR
-	if err := r.addTimeOutAnnotation(rm, remediationCR, now); err != nil {
-		return nil, err
+	// add timeout annotation to remediation CR if it not Succeeded yet
+	if !remediationSucceeded(remediationCR, log) {
+		if err := r.addTimeOutAnnotation(rm, remediationCR, now); err != nil {
+			return nil, err
+		}
 	}
 	// update status (important to do this after CR update, else we won't retry that update in case of error)
 	startedRemediation.TimedOut = &now
@@ -879,6 +884,11 @@ func getTimeoutAt(remediation *remediationv1alpha1.Remediation, configuredTimeou
 func remediationFailed(remediationCR *unstructured.Unstructured, log logr.Logger) bool {
 	succeededCondition := getCondition(remediationCR, commonconditions.SucceededType, log)
 	return succeededCondition != nil && succeededCondition.Status == metav1.ConditionFalse
+}
+
+func remediationSucceeded(remediationCR *unstructured.Unstructured, log logr.Logger) bool {
+	succeededCondition := getCondition(remediationCR, commonconditions.SucceededType, log)
+	return succeededCondition != nil && succeededCondition.Status == metav1.ConditionTrue
 }
 
 func getCondition(remediationCR *unstructured.Unstructured, conditionType string, log logr.Logger) *metav1.Condition {

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -813,6 +813,37 @@ var _ = Describe("Node Health Check CR", func() {
 
 			})
 
+			When("a Succeded remediation times out", func() {
+				BeforeEach(func() {
+					mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer)
+					setupObjects(1, 2, true)
+				})
+
+				It("should not set time out annotation", func() {
+					cr := newRemediationCRForNHC(unhealthyNodeName, underTest)
+					err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
+					Expect(errors.IsNotFound(err)).To(BeFalse())
+
+					// Changing remediation's Status to Succeeded
+					cr = updateStatusCondition(cr)
+					Expect(k8sClient.Status().Update(context.Background(), cr)).To(Succeed())
+
+					// Wait for lease to expire
+					lease := &coordv1.Lease{}
+					err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
+					leaseExpireTime := lease.Spec.AcquireTime.Time.Add(mockRequeueDurationIfLeaseTaken*3 + mockLeaseBuffer)
+					timeLeftForLease := leaseExpireTime.Sub(time.Now())
+					time.Sleep(timeLeftForLease + time.Millisecond*100)
+
+					// Verify that the remediation CR doesn't have the timeout annotation
+					Consistently(func(g Gomega) {
+						err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
+						Expect(errors.IsNotFound(err)).To(BeFalse())
+						_, isNhcTimeOutSet := cr.GetAnnotations()[commonannotations.NhcTimedOut]
+						Expect(isNhcTimeOutSet).To(BeFalse())
+					}, "10s", "1s").Should(Succeed())
+				})
+			})
 		})
 
 		Context("with a single escalating remediation", func() {
@@ -1048,6 +1079,47 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(getRemediationCRForMultiKindSupportTemplate(multiSupportTemplateRef.Name)).To(BeNil())
 					g.Expect(getRemediationCRForMultiKindSupportTemplate(secondMultiSupportTemplateRef.Name)).To(BeNil())
 				}, "5s", "200ms").Should(Succeed(), "CR wasn't deleted")
+			})
+
+			When("a Succeded remediation times out", func() {
+				It("should not set timeout remediation and continue with the next remediation", func() {
+					cr := newRemediationCRForNHC(unhealthyNodeName, underTest)
+					// first call should fail, because the node gets unready in a few seconds only
+					err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
+					Expect(errors.IsNotFound(err)).To(BeTrue())
+
+					// wait until nodes are unhealthy
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+					}, time.Second*10, time.Millisecond*300).Should(Succeed())
+
+					// Set Remediation Succeded condition
+					cr = updateStatusCondition(cr)
+					Expect(k8sClient.Status().Update(context.Background(), cr)).To(Succeed())
+
+					// Wait for 1st remediation to time out and 2nd to start
+					lease := &coordv1.Lease{}
+					err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
+					Expect(err).ToNot(HaveOccurred())
+
+					leaseExpireTime := lease.Spec.AcquireTime.Time.Add(firstRemediationTimeout + mockLeaseBuffer)
+					timeLeftForLease := leaseExpireTime.Sub(time.Now())
+					time.Sleep(timeLeftForLease + time.Millisecond*100)
+
+					// Verify that the remediation CR doesn't have the timeout annotation
+					Consistently(func(g Gomega) {
+						err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
+						Expect(errors.IsNotFound(err)).To(BeFalse())
+						_, isNhcTimeOutSet := cr.GetAnnotations()[commonannotations.NhcTimedOut]
+						Expect(isNhcTimeOutSet).To(BeFalse())
+					}, "10s", "1s").Should(Succeed())
+
+					// Verify the 2nd remediation exists
+					newCr := newRemediationCRForNHCSecondRemediation(unhealthyNodeName, underTest)
+					Eventually(func() error {
+						return k8sClient.Get(context.Background(), client.ObjectKeyFromObject(newCr), newCr)
+					}, time.Second*10, time.Millisecond*300).Should(Succeed())
+				})
 			})
 
 			When("unhealthy condition changes", func() {
@@ -2137,4 +2209,28 @@ func newNode(name string, t v1.NodeConditionType, s v1.ConditionStatus, isContro
 			},
 		},
 	}
+}
+
+// updateStatusCondition sets the Status.Condition Succeeded on an unstructured object
+func updateStatusCondition(o *unstructured.Unstructured) *unstructured.Unstructured {
+	// add .Status to the object if it doesn't exist
+	if _, found, _ := unstructured.NestedFieldNoCopy(o.Object, "status"); !found {
+		o.Object["status"] = make(map[string]interface{})
+	}
+
+	// add .Status.Conditions if it doesn't exist
+	if _, found, _ := unstructured.NestedFieldNoCopy(o.Object, "status", "conditions"); !found {
+		o.Object["status"].(map[string]interface{})["conditions"] = []interface{}{}
+	}
+
+	// add a condition to .Status.Conditions if it doesn't exist
+	conditions := make([]interface{}, 0)
+	conditions = append(conditions, map[string]interface{}{
+		"type":               "Succeeded",
+		"status":             "True",
+		"lastTransitionTime": time.Now().Format(time.RFC3339),
+	})
+
+	o.Object["status"].(map[string]interface{})["conditions"] = conditions
+	return o
 }


### PR DESCRIPTION
#### Why we need this PR

In case a remediator concludes its remediation attempt(s) without failures, but the Node is still unhealthy, it still has to set the Succeded status to True.

In this case, however, the remediation will times out and NHC will set the related annotation, changing the Remediator's Succeded status to False.

#### Changes made

Before setting the timeout annotation on the remediation CR, it ensures that the Succeeded status is not True already.

#### Which issue(s) this PR fixes

https://issues.redhat.com/browse/ECOPROJECT-1881


#### Test plan

Added a new unit-test to verify that if a Remediation sets the succeded status True without fixing the node, NHC does not set the time out annotation.
