### PR TITLE
Fix Makefile all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ KUBECTL=oc
 endif
 
 .PHONY: all
-all: container-build container-push
+all: container-build-ocp container-push
 
 ##@ General
 


### PR DESCRIPTION
#### Why we need this PR

Makefile's "all" target still has the old "container-build" dependency,
which was replaced by "container-build-ocp".

#### Changes made

Replace "container-build" dependency with "container-build-ocp" in Makefile target.

