### PR TITLE
remove code usage of InFlightRemediation 

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -179,6 +179,8 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// set counters to zero for disabled NHC
 	nhc.Status.ObservedNodes = pointer.Int(0)
 	nhc.Status.HealthyNodes = pointer.Int(0)
+	//clear deprecated field before it's removed from the API
+	nhc.Status.InFlightRemediations = nil
 
 	// check if we need to disable NHC because of existing MHCs
 	if disable := r.MHCChecker.NeedDisableNHC(); disable {

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -714,9 +714,9 @@ func (r *NodeHealthCheckReconciler) patchStatus(ctx context.Context, log logr.Lo
 	} else if len(nhc.Spec.PauseRequests) > 0 {
 		nhc.Status.Phase = remediationv1alpha1.PhasePaused
 		nhc.Status.Reason = fmt.Sprintf("NHC is paused: %s", strings.Join(nhc.Spec.PauseRequests, ","))
-	} else if len(nhc.Status.InFlightRemediations) > 0 {
+	} else if r.isRemediating(nhc.Status.UnhealthyNodes) {
 		nhc.Status.Phase = remediationv1alpha1.PhaseRemediating
-		nhc.Status.Reason = fmt.Sprintf("NHC is remediating %v nodes", len(nhc.Status.InFlightRemediations))
+		nhc.Status.Reason = fmt.Sprintf("NHC is remediating %v nodes", len(nhc.Status.UnhealthyNodes))
 	} else {
 		nhc.Status.Phase = remediationv1alpha1.PhaseEnabled
 		nhc.Status.Reason = "NHC is enabled, no ongoing remediation"
@@ -887,6 +887,15 @@ func (r *NodeHealthCheckReconciler) isNodeRemediationExcluded(node *v1.Node) boo
 		_, isNodeExcluded := nodeLabels[commonlabels.ExcludeFromRemediation]
 		return isNodeExcluded
 	}
+}
+
+func (r *NodeHealthCheckReconciler) isRemediating(unhealthyNodes []*remediationv1alpha1.UnhealthyNode) bool {
+	for _, unhealthyNode := range unhealthyNodes {
+		if len(unhealthyNode.Remediations) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func getTimeoutAt(remediation *remediationv1alpha1.Remediation, configuredTimeout *time.Duration) time.Time {

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -89,7 +89,6 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*underTest.Status.HealthyNodes).To(Equal(1))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(6))
-				Expect(underTest.Status.InFlightRemediations).To(BeNil())
 			})
 		})
 
@@ -360,7 +359,6 @@ var _ = Describe("Node Health Check CR", func() {
 					Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 					Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 					Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-					Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(cr.GetName()))
 					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
@@ -415,7 +413,6 @@ var _ = Describe("Node Health Check CR", func() {
 					By("expecting status update")
 					Eventually(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
-						g.Expect(underTest.Status.InFlightRemediations).To(HaveLen(0))
 						g.Expect(underTest.Status.UnhealthyNodes).To(HaveLen(0))
 						g.Expect(*underTest.Status.HealthyNodes).To(Equal(3))
 						g.Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhaseEnabled))
@@ -437,7 +434,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 					Expect(*underTest.Status.HealthyNodes).To(Equal(3))
 					Expect(*underTest.Status.ObservedNodes).To(Equal(7))
-					Expect(underTest.Status.InFlightRemediations).To(BeEmpty())
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(4))
 					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
 					Expect(underTest.Status.UnhealthyNodes[1].Remediations).To(HaveLen(0))
@@ -501,7 +497,6 @@ var _ = Describe("Node Health Check CR", func() {
 						g.Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 					}, "2s", "100ms").Should(Succeed())
 					Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-					Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(cr.GetName()))
 					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
@@ -552,7 +547,6 @@ var _ = Describe("Node Health Check CR", func() {
 				})
 
 				It("remediation cr should not be processed", func() {
-					Expect(underTest.Status.InFlightRemediations).To(BeEmpty())
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(unhealthyNodeName))
 					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
@@ -582,7 +576,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 					By("Verifying node is remediated by 1st NHC")
 					Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
-					Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
 
@@ -600,7 +593,6 @@ var _ = Describe("Node Health Check CR", func() {
 					// ensure no remediation starts
 					Consistently(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(otherTestCR), otherTestCR)).To(Succeed())
-						g.Expect(otherTestCR.Status.InFlightRemediations).To(HaveLen(0))
 						g.Expect(otherTestCR.Status.UnhealthyNodes).To(HaveLen(1))
 						g.Expect(otherTestCR.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
 					}, "5s", "1s").Should(Succeed(), "duplicate remediation detected!")
@@ -688,7 +680,6 @@ var _ = Describe("Node Health Check CR", func() {
 						// Status should be updated even though lease isn't owned by us anymore
 						Eventually(func(g Gomega) {
 							g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
-							g.Expect(underTest.Status.InFlightRemediations).To(BeEmpty())
 							g.Expect(underTest.Status.UnhealthyNodes).To(BeEmpty())
 						}, "2s", "100ms").Should(Succeed(), "status update failed")
 
@@ -719,7 +710,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 						Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 						Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-						Expect(underTest.Status.InFlightRemediations).To(HaveLen(0))
 						Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(cr.GetName()))
 						Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(0))
@@ -890,7 +880,6 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 					g.Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 					g.Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-					g.Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 					g.Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					g.Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(cr.GetName()))
 					g.Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
@@ -934,7 +923,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 					g.Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 					g.Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-					g.Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 					g.Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 					g.Expect(underTest.Status.UnhealthyNodes[0].Name).To(Equal(cr.GetName()))
 					g.Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(2))
@@ -1035,7 +1023,6 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 				Expect(*underTest.Status.HealthyNodes).To(Equal(3))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-				Expect(underTest.Status.InFlightRemediations).To(HaveLen(0))
 				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(0))
 				Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhaseEnabled))
 
@@ -1301,7 +1288,6 @@ var _ = Describe("Node Health Check CR", func() {
 					))
 					Expect(*underTest.Status.HealthyNodes).To(Equal(6))
 					Expect(*underTest.Status.ObservedNodes).To(Equal(9))
-					Expect(underTest.Status.InFlightRemediations).To(HaveLen(2))
 					Expect(underTest.Status.UnhealthyNodes).To(HaveLen(3))
 					Expect(underTest.Status.UnhealthyNodes).To(ContainElements(
 						And(
@@ -1481,7 +1467,6 @@ var _ = Describe("Node Health Check CR", func() {
 						}, "10s", "1s").Should(Succeed())
 						Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 						Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-						Expect(underTest.Status.InFlightRemediations).To(HaveLen(0))
 						Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes).To(ContainElements(
 							And(
@@ -1505,7 +1490,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 						Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 						Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-						Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes).To(ContainElements(
 							And(
@@ -1524,7 +1508,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 						Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 						Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-						Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 						Expect(underTest.Status.UnhealthyNodes).To(ContainElements(
 							And(
@@ -1551,7 +1534,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 				Expect(*underTest.Status.HealthyNodes).To(Equal(0))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(0))
-				Expect(underTest.Status.InFlightRemediations).To(BeEmpty())
 				Expect(underTest.Status.UnhealthyNodes).To(BeEmpty())
 				Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhasePaused))
 				Expect(underTest.Status.Reason).ToNot(BeEmpty())
@@ -1576,7 +1558,6 @@ var _ = Describe("Node Health Check CR", func() {
 
 				Expect(*underTest.Status.HealthyNodes).To(Equal(0))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(0))
-				Expect(underTest.Status.InFlightRemediations).To(BeEmpty())
 				Expect(underTest.Status.UnhealthyNodes).To(BeEmpty())
 				Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhaseEnabled))
 				Expect(underTest.Status.Reason).ToNot(BeEmpty())
@@ -1590,7 +1571,6 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 				Expect(*underTest.Status.HealthyNodes).To(Equal(2))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(3))
-				Expect(underTest.Status.InFlightRemediations).To(HaveLen(1))
 				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 			})
 

--- a/controllers/resources/status.go
+++ b/controllers/resources/status.go
@@ -13,15 +13,6 @@ import (
 )
 
 func UpdateStatusRemediationStarted(node *corev1.Node, nhc *remediationv1alpha1.NodeHealthCheck, remediationCR *unstructured.Unstructured) {
-	if _, exists := nhc.Status.InFlightRemediations[remediationCR.GetName()]; !exists {
-		if nhc.Status.InFlightRemediations == nil {
-			nhc.Status.InFlightRemediations = make(map[string]metav1.Time, 1)
-		}
-		if _, ok := nhc.Status.InFlightRemediations[node.GetName()]; !ok {
-			nhc.Status.InFlightRemediations[node.GetName()] = remediationCR.GetCreationTimestamp()
-		}
-	}
-
 	var templateName string
 	if remediationCR.GetAnnotations() != nil {
 		templateName = remediationCR.GetAnnotations()[annotations.TemplateNameAnnotation]
@@ -68,7 +59,6 @@ func UpdateStatusRemediationStarted(node *corev1.Node, nhc *remediationv1alpha1.
 }
 
 func UpdateStatusNodeHealthy(nodeName string, nhc *remediationv1alpha1.NodeHealthCheck) {
-	delete(nhc.Status.InFlightRemediations, nodeName)
 	for i, _ := range nhc.Status.UnhealthyNodes {
 		if nhc.Status.UnhealthyNodes[i].Name == nodeName {
 			for _, remediation := range nhc.Status.UnhealthyNodes[i].Remediations {

--- a/e2e/nhc_e2e_test.go
+++ b/e2e/nhc_e2e_test.go
@@ -238,7 +238,6 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 					By("ensuring status is set")
 					Eventually(func(g Gomega) {
 						nhc = getNodeHealthCheck()
-						g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
 						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
 						g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(2))
 						g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
@@ -285,7 +284,6 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 					By("ensuring status is set")
 					Eventually(func(g Gomega) {
 						nhc = getNodeHealthCheck()
-						g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
 						g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
 						g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
 						g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
@@ -407,7 +405,6 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 				By("ensuring status is set")
 				Eventually(func(g Gomega) {
 					nhc = getNodeHealthCheck()
-					g.Expect(nhc.Status.InFlightRemediations).To(HaveLen(1))
 					g.Expect(nhc.Status.UnhealthyNodes).To(HaveLen(1))
 					g.Expect(nhc.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
 					g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))


### PR DESCRIPTION


<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
InFlightRemediation status field is deprecated and ultimately we want to remove it.
As a second Phase (it was deprecated in the first phase), before removing it from the API we remove code usages to it therefore ceasing to update it.
Since it's optional it will not show even though it is still part of the API.

#### Changes made
Removing code usages of InFlightRemediation


#### Which issue(s) this PR fixes
[ECOPROJECT-1933](https://issues.redhat.com//browse/ECOPROJECT-1933)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
