### PR TITLE
prevent multiple "node unhealthy" events

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -424,6 +424,7 @@ func (r *NodeHealthCheckReconciler) matchesUnhealthyConditions(nhc *remediationv
 		nodeConditionByType[nc.Type] = nc
 	}
 
+	isNodeRemediating := r.isRemediatingNode(nhc.Status.UnhealthyNodes, node.GetName())
 	var expiresAfter *time.Duration
 	for _, c := range nhc.Spec.UnhealthyConditions {
 		n, exists := nodeConditionByType[c.Type]
@@ -436,7 +437,7 @@ func (r *NodeHealthCheckReconciler) matchesUnhealthyConditions(nhc *remediationv
 				// unhealthy condition duration expired, node is unhealthy
 				r.Log.Info("Node matches unhealthy condition", "node", node.GetName(), "condition type", c.Type, "condition status", c.Status)
 				//In case a remediation is already created no need to repeat this event
-				if !r.isRemediatingNode(nhc.Status.UnhealthyNodes, node.GetName()) {
+				if !isNodeRemediating {
 					commonevents.NormalEventf(r.Recorder, nhc, utils.EventReasonDetectedUnhealthy, "Node matches unhealthy condition. Node %q, condition type %q, condition status %q", node.GetName(), c.Type, c.Status)
 				}
 				return true, nil

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -806,6 +806,20 @@ var _ = Describe("Node Health Check CR", func() {
 
 			})
 
+			When("node stays unhealthy", func() {
+				BeforeEach(func() {
+					//mocking lease in order to reassure lease extension will trigger a second reconcile (in which the event shouldn't be triggered)
+					mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer)
+					setupObjects(1, 2, true)
+				})
+				It("Node unhealthy event should occur once", func() {
+					verifyEvent("Normal", utils.EventReasonDetectedUnhealthy, fmt.Sprintf("Node matches unhealthy condition. Node %q, condition type %q, condition status %q", unhealthyNodeName, "Ready", "Unknown"))
+					//After verification event is extracted so this is how we verify it occurred only once
+					verifyNoEvent("Normal", utils.EventReasonDetectedUnhealthy, fmt.Sprintf("Node matches unhealthy condition. Node %q, condition type %q, condition status %q", unhealthyNodeName, "Ready", "Unknown"))
+
+				})
+			})
+
 			When("a Succeded remediation times out", func() {
 				BeforeEach(func() {
 					mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer)


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
`DetectedUnhealthy` is generated multiple times for the same node, which might be confusing for the user. 

#### Changes made
In case a remediation is already created for a node, skip `DetectedUnhealthy` event


#### Which issue(s) this PR fixes
[ECOPROJECT-1890](https://issues.redhat.com//browse/ECOPROJECT-1890)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
