### PR TITLE
Fix Go version used in Dockerfile to build the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream9 AS builder
-RUN yum install git golang -y
+RUN dnf install -y jq git \
+    && dnf clean all -y
 
 WORKDIR /workspace
 
-# Copy the Go Modules manifests
+# Copy the Go Modules manifests for detecting Go version
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# use latest Go z release
-ENV GOTOOLCHAIN=auto
+RUN \
+    # get Go version from mod file
+    export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
+    echo ${GO_VERSION} && \
+    # find filename for latest z version from Go download page
+    export GO_FILENAME=$(curl -sL 'https://go.dev/dl/?mode=json&include=all' | jq -r "[.[] | select(.version | startswith(\"go${GO_VERSION}\"))][0].files[] | select(.os == \"linux\" and .arch == \"amd64\") | .filename") && \
+    echo ${GO_FILENAME} && \
+    # download and unpack
+    curl -sL -o go.tar.gz "https://golang.org/dl/${GO_FILENAME}" && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
 
-# Ensure correct Go version
-RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
-    go get go@${GO_VERSION} && \
-    go version
+# add Go to PATH
+ENV PATH="/usr/local/go/bin:${PATH}"
+RUN go version
 
 # Copy the go source
 COPY vendor/ vendor/


### PR DESCRIPTION
#### Why we need this PR

The Dockerfile currently installs the Go version defined in go.mod using go get. However, this method doesn't ensure that the just-installed Go version is the same one used to build the binary. Instead, the binary is still built with the Go version released with the container.


#### Changes made

This change downloads and extracts the Go archive corresponding to the go.mod file and sets the PATH to prioritize the current installation.


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
