### PR TITLE
Add missing metadata dependency to ocp bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ bundle-base: manifests kustomize operator-sdk ## Generate bundle manifests and m
 	cd config/manifests/base && $(KUSTOMIZE) edit set image controller=$(IMG) && $(KUSTOMIZE) edit set image kube-rbac-proxy=$(RBAC_PROXY_IMAGE)
 	cd config/optional/console-plugin && $(KUSTOMIZE) edit set image console-plugin=${CONSOLE_PLUGIN_IMAGE}
 	$(KUSTOMIZE) build config/manifests/base | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	cp config/metadata/dependencies.yaml bundle/metadata/
+	$(MAKE) add-metadata-dependency
 	$(MAKE) bundle-validate
 
 export CSV="./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml"
@@ -345,6 +345,10 @@ add-replaces-field: ## Add replaces field to the CSV
 add-community-edition-to-display-name: ## Add the "Community Edition" suffix to the display name
 	sed -r -i "s|displayName: Node Health Check Operator|displayName: Node Health Check Operator - Community Edition|;" ${CSV}
 
+.PHONY: add-metadata-dependency
+add-metadata-dependency: ## Add metadata/dependency.yaml to the bundle
+	cp config/metadata/dependencies.yaml bundle/metadata/
+
 .PHONY: bundle-okd
 bundle-okd: ocp-version-check yq bundle-base ## Generate bundle manifests and metadata for OKD, then validate generated files.
 	$(KUSTOMIZE) build config/manifests/okd | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
@@ -364,6 +368,7 @@ bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, th
 	#   https://osbs.readthedocs.io/en/osbs_ocp3/users.html?#pinning-pullspecs-for-related-images
 	$(YQ) -i '( .spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name == "manager") | .env) += [{"name": "RELATED_IMAGE_MUST_GATHER", "value": "${MUST_GATHER_IMAGE}"}]' ${CSV}
 	$(MAKE) add-console-plugin-annotation
+	$(MAKE) add-metadata-dependency
 	# add OCP annotations
 	$(YQ) -i '.metadata.annotations."operators.openshift.io/valid-subscription" = "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"' ${CSV}
 	# new infrastructure annotations see https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-(New)RequiredInfrastructureAnnotations


### PR DESCRIPTION
#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
The OCP bundle is created from scratch, which means it deletes the bundle folder previously created by bundle-base target, together with the metadata/dependency.yaml

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
Ensure that the OCP bundle contains the metadata/dependency.yaml



#### Which issue(s) this PR fixes

https://issues.redhat.com/browse/ECOPROJECT-1981
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan

- Delete the bundle folder
- make bundle-ocp
- verify the file bundle/metadata/dependency.yaml exists and matches config/metadata/dependency.yaml
