### PR TITLE
Reconcile if ExcludeFromRemediation label is removed

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -357,7 +357,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		if r.isNodeRemediationExcluded(&node) {
-			msg := fmt.Sprintf("Skipped remediation because node %s is marked to exclude remediations", node.GetName())
+			msg := fmt.Sprintf("Remediation skipped on node %s: node has Exclude from Remediation label", node.GetName())
 			log.Info(msg)
 			commonevents.WarningEvent(r.Recorder, nhc, utils.EventReasonRemediationSkipped, msg)
 			continue

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -1798,6 +1798,8 @@ var _ = Describe("Node Health Check CR", func() {
 	Context("Node updates", func() {
 		var oldConditions []v1.NodeCondition
 		var newConditions []v1.NodeCondition
+		var oldLabels map[string]string
+		var newLabels map[string]string
 
 		When("no Ready condition exists on new node", func() {
 			BeforeEach(func() {
@@ -1925,6 +1927,68 @@ var _ = Describe("Node Health Check CR", func() {
 			})
 			It("should request reconcile", func() {
 				Expect(conditionsNeedReconcile(oldConditions, newConditions)).To(BeTrue())
+			})
+		})
+
+		When("labels are equal", func() {
+			BeforeEach(func() {
+				oldLabels = map[string]string{
+					commonLabels.ExcludeFromRemediation: "true",
+				}
+				newLabels = map[string]string{
+					commonLabels.ExcludeFromRemediation: "true",
+				}
+			})
+			It("should not request reconcile", func() {
+				Expect(labelsNeedReconcile(oldLabels, newLabels)).To(BeFalse())
+			})
+		})
+
+		When("label ExcludeFromRemediation is added", func() {
+			BeforeEach(func() {
+				oldLabels = map[string]string{}
+				newLabels = map[string]string{
+					commonLabels.ExcludeFromRemediation: "true",
+				}
+			})
+			It("should request reconcile", func() {
+				Expect(labelsNeedReconcile(oldLabels, newLabels)).To(BeTrue())
+			})
+		})
+
+		When("label ExcludeFromRemediation is removed", func() {
+			BeforeEach(func() {
+				oldLabels = map[string]string{
+					commonLabels.ExcludeFromRemediation: "true",
+				}
+				newLabels = map[string]string{}
+			})
+			It("should request reconcile", func() {
+				Expect(labelsNeedReconcile(oldLabels, newLabels)).To(BeTrue())
+			})
+		})
+
+		When("A label different than ExcludeFromRemediation is added", func() {
+			BeforeEach(func() {
+				oldLabels = map[string]string{}
+				newLabels = map[string]string{
+					"some-random-label": "true",
+				}
+			})
+			It("should not request reconcile", func() {
+				Expect(labelsNeedReconcile(oldLabels, newLabels)).To(BeFalse())
+			})
+		})
+
+		When("A label different than ExcludeFromRemediation is removed", func() {
+			BeforeEach(func() {
+				oldLabels = map[string]string{
+					"some-random-label": "true",
+				}
+				newLabels = map[string]string{}
+			})
+			It("should not request reconcile", func() {
+				Expect(labelsNeedReconcile(oldLabels, newLabels)).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
In case ExcludeFromRemediation label is present, remediation is skipped,
however if the Node is still unhealthy when the label is removed it
should be reconciled.


#### Changes made
<!-- Outline the specific changes made in this merge request. -->
Watch for changes in the Node's labels. If ExcludeFromRemediation is removed reconcile the Node.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

https://issues.redhat.com/browse/ECOPROJECT-1988

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
