### PR TITLE
Fix e2e

### DIFF
--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -996,8 +996,6 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(newCr), newCr)).To(Succeed())
 					g.Expect(cr.GetAnnotations()).To(HaveKeyWithValue(Equal("remediation.medik8s.io/nhc-timed-out"), Not(BeNil())))
 					g.Expect(newCr.GetName()).To(Equal(unhealthyNodeName))
-					g.Expect(newCr.GetAnnotations()).ToNot(HaveKey(Equal(commonannotations.NodeNameAnnotation)))
-
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
 				// get updated NHC

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -129,10 +129,10 @@ func (m *manager) generateRemediationCR(name string, healthCheckOwnerRef *metav1
 
 	if annotations.HasMultipleTemplatesAnnotation(template) {
 		remediationCR.SetGenerateName(fmt.Sprintf("%s-", name))
-		remediationCR.SetAnnotations(map[string]string{commonannotations.NodeNameAnnotation: name, annotations.TemplateNameAnnotation: template.GetName()})
 	} else {
 		remediationCR.SetName(name)
 	}
+	remediationCR.SetAnnotations(map[string]string{commonannotations.NodeNameAnnotation: name, annotations.TemplateNameAnnotation: template.GetName()})
 
 	remediationCR.SetNamespace(template.GetNamespace())
 	remediationCR.SetResourceVersion("")

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -127,7 +128,7 @@ func (m *manager) generateRemediationCR(name string, healthCheckOwnerRef *metav1
 	unstructured.SetNestedField(remediationCR.Object, templateSpec, "spec")
 
 	if annotations.HasMultipleTemplatesAnnotation(template) {
-		remediationCR.SetGenerateName(name)
+		remediationCR.SetGenerateName(fmt.Sprintf("%s-", name))
 		remediationCR.SetAnnotations(map[string]string{commonannotations.NodeNameAnnotation: name, annotations.TemplateNameAnnotation: template.GetName()})
 	} else {
 		remediationCR.SetName(name)

--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -2,6 +2,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+
+	commonannotations "github.com/medik8s/common/pkg/annotations"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +13,9 @@ import (
 
 func ensureRemediationResourceExists(name string, namespace string, remediationResource schema.GroupVersionResource) func() error {
 	return func() error {
-		_, err := dynamicClient.Resource(remediationResource).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		// The CR name doesn't always match the node name in case multiple CRs of same type for the same node are supported
+		// So list all, and look for the node name in the annotation
+		list, err := dynamicClient.Resource(remediationResource).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				log.Info("didn't find remediation resource yet")
@@ -19,7 +24,13 @@ func ensureRemediationResourceExists(name string, namespace string, remediationR
 			}
 			return err
 		}
-		log.Info("found remediation resource")
-		return nil
+		for _, cr := range list.Items {
+			if nodeName, exists := cr.GetAnnotations()[commonannotations.NodeNameAnnotation]; exists && nodeName == name {
+				log.Info("found remediation resource")
+				return nil
+			}
+		}
+		log.Info("didn't find remediation resource yet")
+		return fmt.Errorf("not found")
 	}
 }


### PR DESCRIPTION
#### Why we need this PR
Broken e2e test because of SNR support multiple templates feature

#### Changes made
Look for CR with node name in annotation instead of CR name

 Also:
- always set node name annotation, I don't see a reason to not do that
- make CR name nicer in case it doesn't match node name by adding a "-" between node name and suffix
