### PR TITLE
Remove snr's dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,6 @@ bundle-base: manifests kustomize operator-sdk ## Generate bundle manifests and m
 	cd config/manifests/base && $(KUSTOMIZE) edit set image controller=$(IMG) && $(KUSTOMIZE) edit set image kube-rbac-proxy=$(RBAC_PROXY_IMAGE)
 	cd config/optional/console-plugin && $(KUSTOMIZE) edit set image console-plugin=${CONSOLE_PLUGIN_IMAGE}
 	$(KUSTOMIZE) build config/manifests/base | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	$(MAKE) add-metadata-dependency
 	$(MAKE) bundle-validate
 
 export CSV="./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml"
@@ -345,10 +344,6 @@ add-replaces-field: ## Add replaces field to the CSV
 add-community-edition-to-display-name: ## Add the "Community Edition" suffix to the display name
 	sed -r -i "s|displayName: Node Health Check Operator|displayName: Node Health Check Operator - Community Edition|;" ${CSV}
 
-.PHONY: add-metadata-dependency
-add-metadata-dependency: ## Add metadata/dependency.yaml to the bundle
-	cp config/metadata/dependencies.yaml bundle/metadata/
-
 .PHONY: bundle-okd
 bundle-okd: ocp-version-check yq bundle-base ## Generate bundle manifests and metadata for OKD, then validate generated files.
 	$(KUSTOMIZE) build config/manifests/okd | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
@@ -368,7 +363,6 @@ bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, th
 	#   https://osbs.readthedocs.io/en/osbs_ocp3/users.html?#pinning-pullspecs-for-related-images
 	$(YQ) -i '( .spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name == "manager") | .env) += [{"name": "RELATED_IMAGE_MUST_GATHER", "value": "${MUST_GATHER_IMAGE}"}]' ${CSV}
 	$(MAKE) add-console-plugin-annotation
-	$(MAKE) add-metadata-dependency
 	# add OCP annotations
 	$(YQ) -i '.metadata.annotations."operators.openshift.io/valid-subscription" = "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"' ${CSV}
 	# new infrastructure annotations see https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-(New)RequiredInfrastructureAnnotations

--- a/Makefile
+++ b/Makefile
@@ -386,14 +386,6 @@ bundle-ocp-ci: yq ## Generate OCP bundle for CI, without overriding the image pu
 bundle-k8s: bundle-base ## Generate bundle manifests and metadata for K8s community, then validate generated files.
 	$(KUSTOMIZE) build config/manifests/k8s | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
-	sed -r -i "/displayName: Node Health Check Operator/ i\    " ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    ### Notes" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    In case Pod Security Admission is used, please allow Pods to run" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    in the \"privileged\" Pod Security Standard policy." ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    This is required by the dependent Self Node Remediation operator" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    for rebooting unhealthy nodes, and can be done by labeling the" ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    the target namespace accordingly before installing NHC." ${CSV}
-	sed -r -i "/displayName: Node Health Check Operator/ i\    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/ ." ${CSV}
 	$(MAKE) add-community-edition-to-display-name
 	$(MAKE) bundle-validate
 

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/node-healthcheck-operator:v0.0.1
     createdAt: ""
-    description: Detect failed Nodes and trigger remediation with e.g. Self Node Remediation.
+    description: Detect failed Nodes and trigger remediation with a remediation operator.
     olm.skipRange: '>=0.0.1'
     operatorframework.io/suggested-namespace: openshift-workload-availability
     operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
@@ -232,8 +232,6 @@ spec:
     - Fence Agents Remediation (FAR)
     - Machine Deletion Remediation (MDR)
 
-    SNR is installed automatically when installing NHC.
-
     #### Self Node Remediation (SNR)
     SNR uses watchdog timers and heuristics to ensure nodes enter a safe state
     (no longer hosting workloads) within a known and finite period of time,
@@ -249,14 +247,6 @@ spec:
 
     #### Machine Deletion Remediation (MDR)
     MDR is limited to OpenShift, and it uses Machine API for reprovisioning unhealthy nodes by deleting their machines.
-    
-    ### Notes
-    In case Pod Security Admission is used, please allow Pods to run
-    in the "privileged" Pod Security Standard policy.
-    This is required by the dependent Self Node Remediation operator
-    for rebooting unhealthy nodes, and can be done by labeling the
-    the target namespace accordingly before installing NHC.
-    For details see https://kubernetes.io/docs/concepts/security/pod-security-admission/ .
   displayName: Node Health Check Operator - Community Edition
   icon:
   - base64data: base64EncodedIcon

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,6 +1,0 @@
-dependencies:
-- type: olm.gvk
-  value:
-    group: self-node-remediation.medik8s.io
-    kind: SelfNodeRemediation
-    version: v1alpha1

--- a/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/node-healthcheck-operator:v0.0.1
     createdAt: ""
-    description: Detect failed Nodes and trigger remediation with e.g. Self Node Remediation.
+    description: Detect failed Nodes and trigger remediation with a remediation operator.
     olm.skipRange: '>=0.0.1'
     operatorframework.io/suggested-namespace: openshift-workload-availability
     operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
@@ -191,8 +191,6 @@ spec:
     - Self Node Remediation (SNR)
     - Fence Agents Remediation (FAR)
     - Machine Deletion Remediation (MDR)
-
-    SNR is installed automatically when installing NHC.
 
     #### Self Node Remediation (SNR)
     SNR uses watchdog timers and heuristics to ensure nodes enter a safe state

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -1,6 +1,0 @@
-dependencies:
-- type: olm.gvk
-  value:
-    group: self-node-remediation.medik8s.io
-    kind: SelfNodeRemediation
-    version: v1alpha1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,9 +35,6 @@ For configuration of NHC, please follow instructions in the [configuration guide
 
 ## Installing a remediator
 
-Currently, NHC has the [Self Node Remediation (SNR) operator](https://www.medik8s.io/remediation/self-node-remediation/self-node-remediation/)
-configured as dependency. This means that SNR will be automatically installed by OLM.
-
-If you want to use another remediator, you have to install it manually.
+You need to install a remediator manually.
 You can find a list of remediators known to work with NHC on the
 [Medik8s website](https://www.medik8s.io/remediation/remediation/#implementations)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -8,11 +8,6 @@ when debugging issues, since many steps can potentially fail. See also our
 
 - various internal components are initialized
 - RBAC configuration is updated for [role aggregation with remediators](./contributing.md#rbac-and-role-aggregation)
-- old default configs are updated if found:
-  - update selector to !control-plane && !master
-  - update remediator to SelfNodeRemediation
-  - **Note** due to the increasing number of potential configurations, the latest
-    version of NHC is not creating a default config CR anymore
 - the UI plugin is configured (on OKD / OpenShift only)
 
 ### When a NHC CR is created / updated / deleted, or an observed node's status condition changes


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR

- NHC no longer has a default CR with SNR template
- Users prefer more flexibility 
- Due to changes in the next OLM version we'd like to remove SNR dependency.
The main reason is that the current dependency will prevent NHC upgarde in case SNR isn't installed 
#### Changes made
Removing dependency in Self Node Remediation 


**Note**: I haven't updated NodeHealthCheck sample file, since I think it's still nice to have some valid template populated  when NHC  is created manually 

#### Which issue(s) this PR fixes
[ECOPROJECT-1216](https://issues.redhat.com//browse/ECOPROJECT-1216)
#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
