### PR TITLE
Fix regressions related to "multiple same kind remediation support"

### DIFF
--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -580,7 +580,8 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 				log.Info("skipping timeout annotation on remediation CR: Succeeded condition is True", "CR name", remediationCR.GetName())
 			}
 			startedRemediation := resources.FindStatusRemediation(node, nhc, func(r *remediationv1alpha1.Remediation) bool {
-				return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind()
+				return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind() &&
+					(r.TemplateName == "" || r.TemplateName == currentTemplate.GetName())
 			})
 
 			if startedRemediation == nil {
@@ -623,7 +624,8 @@ func (r *NodeHealthCheckReconciler) remediate(ctx context.Context, node *v1.Node
 	}
 
 	startedRemediation := resources.FindStatusRemediation(node, nhc, func(r *remediationv1alpha1.Remediation) bool {
-		return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind()
+		return r.Resource.GroupVersionKind() == remediationCR.GroupVersionKind() &&
+			(r.TemplateName == "" || r.TemplateName == currentTemplate.GetName())
 	})
 
 	if startedRemediation == nil {

--- a/controllers/resources/status.go
+++ b/controllers/resources/status.go
@@ -8,15 +8,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
-	"github.com/medik8s/node-healthcheck-operator/controllers/utils/annotations"
+	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
 	"github.com/medik8s/node-healthcheck-operator/metrics"
 )
 
 func UpdateStatusRemediationStarted(node *corev1.Node, nhc *remediationv1alpha1.NodeHealthCheck, remediationCR *unstructured.Unstructured) {
-	var templateName string
-	if remediationCR.GetAnnotations() != nil {
-		templateName = remediationCR.GetAnnotations()[annotations.TemplateNameAnnotation]
-	}
+	templateName := utils.GetTemplateNameFromCR(*remediationCR)
 	remediation := remediationv1alpha1.Remediation{
 		Resource: corev1.ObjectReference{
 			Kind:       remediationCR.GetKind(),

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	commonannotations "github.com/medik8s/common/pkg/annotations"
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
@@ -132,4 +133,17 @@ func GetMachineNamespaceName(node *v1.Node) (namespace, name string, err error) 
 		return "", "", errors.Wrapf(err, "failed to split machine annotation value into namespace + name: %v", namespacedMachine)
 	}
 	return
+}
+
+// GetNodeNameFromCR returns the node name from the given CR. If the CR has a nodeName annotation, it will return its
+// value, otherwise it will return the CR name.
+func GetNodeNameFromCR(cr unstructured.Unstructured) string {
+	ann := cr.GetAnnotations()
+	if ann == nil {
+		return cr.GetName()
+	}
+	if _, exists := ann[commonannotations.NodeNameAnnotation]; exists {
+		return ann[commonannotations.NodeNameAnnotation]
+	}
+	return cr.GetName()
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	"github.com/medik8s/node-healthcheck-operator/controllers/utils/annotations"
 )
 
 const (
@@ -146,4 +147,16 @@ func GetNodeNameFromCR(cr unstructured.Unstructured) string {
 		return ann[commonannotations.NodeNameAnnotation]
 	}
 	return cr.GetName()
+}
+
+// GetTemplateNameFromCR returns the template name from the given CR, if set.
+func GetTemplateNameFromCR(cr unstructured.Unstructured) string {
+	ann := cr.GetAnnotations()
+	if ann == nil {
+		return ""
+	}
+	if _, exists := ann[annotations.TemplateNameAnnotation]; exists {
+		return ann[annotations.TemplateNameAnnotation]
+	}
+	return ""
 }


### PR DESCRIPTION
#### Why we need this PR
In https://github.com/medik8s/node-healthcheck-operator/pull/301 we added support for multiple escalating remediations of the same remediation kind.

While investigating a report about false events about skipping control plane remediation I noticed that we have several issues related to that new feature, because we just checked the CR name when comparing with node names, instead of the new node name annotation.

#### Changes made

The first commit updates the unit tests in order reveal 3 of the (at least) 4 issues:

- `[FAIL] Node Health Check CR Reconciliation with a single escalating remediation with multiple same kind support when an old remediation cr exists [It] an alert flag is set on remediation cr`
- `[FAIL] Node Health Check CR Reconciliation with expected permanent node deletion [It] it should delete orphaned CR when node is deleted`
- `[FAIL] Node Health Check CR Reconciliation control plane nodes when two control plane nodes are unhealthy [It] should remediate one after another` -> this is about the false event
- the 4th issue is very rare edge case, not covered in unit tests: the timeout annotation is not added to a remediation CR, when it belongs to a later remediation with same kind, and lease expired while it's processed

The next 2 commits fix the issues in the code.

#### Which issue(s) this PR fixes

The false event was mentioned in:
[ECOPROJECT-2057](https://issues.redhat.com//browse/ECOPROJECT-2057)

#### Test plan
As mentioned already, first commit updates tests to reveal the issues