### PR TITLE
Use console/v1

### DIFF
--- a/controllers/console/plugin.go
+++ b/controllers/console/plugin.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 
 	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 )
@@ -66,7 +66,7 @@ func CreateOrUpdatePlugin(ctx context.Context, cl client.Client, caps cluster.Ca
 
 func createOrUpdateConsolePlugin(ctx context.Context, namespace string, cl client.Client) error {
 	cp := getConsolePlugin(namespace)
-	oldCP := &v1alpha1.ConsolePlugin{}
+	oldCP := &consolev1.ConsolePlugin{}
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(cp), oldCP); apierrors.IsNotFound(err) {
 		if err := cl.Create(ctx, cp); err != nil {
 			return errors.Wrap(err, "could not create console plugin")
@@ -83,20 +83,23 @@ func createOrUpdateConsolePlugin(ctx context.Context, namespace string, cl clien
 	return nil
 }
 
-func getConsolePlugin(namespace string) *v1alpha1.ConsolePlugin {
-	return &v1alpha1.ConsolePlugin{
+func getConsolePlugin(namespace string) *consolev1.ConsolePlugin {
+	return &consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: PluginName,
 			// TODO set owner ref for deletion when operator is uninstalled
 			// but which resource to use, needs to be cluster scoped
 		},
-		Spec: v1alpha1.ConsolePluginSpec{
+		Spec: consolev1.ConsolePluginSpec{
 			DisplayName: "Node Remediation",
-			Service: v1alpha1.ConsolePluginService{
-				Name:      ServiceName,
-				Namespace: namespace,
-				Port:      ServicePort,
-				BasePath:  "/",
+			Backend: consolev1.ConsolePluginBackend{
+				Type: consolev1.Service,
+				Service: &consolev1.ConsolePluginService{
+					Name:      ServiceName,
+					Namespace: namespace,
+					Port:      ServicePort,
+					BasePath:  "/",
+				},
 			},
 		},
 	}

--- a/controllers/initializer/suite_test.go
+++ b/controllers/initializer/suite_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	consolev1alpha "github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 
 	remediationv1alpha1 "github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
 )
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 
 	scheme.AddToScheme(scheme.Scheme)
 	Expect(remediationv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
-	Expect(consolev1alpha.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(consolev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
@@ -126,7 +126,7 @@ var _ = BeforeSuite(func() {
 	err = apiextensionsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(consolev1alpha1.Install(scheme.Scheme)).To(Succeed())
+	Expect(consolev1.Install(scheme.Scheme)).To(Succeed())
 
 	k8sClient, err = ctrl.New(config, ctrl.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/e2e/nhc_console_e2e_test.go
+++ b/e2e/nhc_console_e2e_test.go
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 
 	"github.com/medik8s/node-healthcheck-operator/controllers/console"
 	"github.com/medik8s/node-healthcheck-operator/e2e/utils"
@@ -20,15 +20,15 @@ var _ = Describe("e2e - console", Label("NHC"), func() {
 	When("when the operator and the console plugin is deployed", labelOcpOnly, func() {
 		It("the plugin manifest should be served", func() {
 			By("getting the ConsolePlugin")
-			plugin := &consolev1alpha1.ConsolePlugin{}
+			plugin := &consolev1.ConsolePlugin{}
 			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: console.PluginName}, plugin)).To(Succeed(), "failed to get ConsolePlugin")
 
 			By("getting the plugin Service")
 			svc := &v1.Service{}
-			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Namespace: plugin.Spec.Service.Namespace, Name: plugin.Spec.Service.Name}, svc)).To(Succeed(), "failed to get plugin Service")
+			Expect(k8sClient.Get(context.Background(), ctrl.ObjectKey{Namespace: plugin.Spec.Backend.Service.Namespace, Name: plugin.Spec.Backend.Service.Name}, svc)).To(Succeed(), "failed to get plugin Service")
 
 			By("getting the console manifest")
-			manifestUrl := fmt.Sprintf("https://%s:%d/%s/plugin-manifest.json", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port, plugin.Spec.Service.BasePath)
+			manifestUrl := fmt.Sprintf("https://%s:%d/%s/plugin-manifest.json", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port, plugin.Spec.Backend.Service.BasePath)
 			cmd := fmt.Sprintf("curl -k %s", manifestUrl)
 			node := utils.GetWorkerNodes(k8sClient)[0]
 			output, err := utils.RunCommandInCluster(clientSet, node.Name, testNsName, cmd, log)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -76,7 +76,7 @@ func init() {
 
 	utilruntime.Must(machinev1beta1.Install(scheme))
 	utilruntime.Must(operatorv1.Install(scheme))
-	utilruntime.Must(v1alpha1.Install(scheme))
+	utilruntime.Must(consolev1.Install(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
#### Why we need this PR
ConsolePlugin doesn't work anymore on OCP 4.17

#### Changes made
Use console v1 instead of v1alpha1

Fixes [ECOPROJECT-2078](https://issues.redhat.com//browse/ECOPROJECT-2078)
