### PR TITLE
MHC created CR isn't deleted by the remediator

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -404,17 +404,15 @@ func (r *MachineHealthCheckReconciler) remediate(target resources.Target, rm res
 		return errors.Wrapf(err, "failed to get remediation template")
 	}
 
+	var nodeNamePtr *string
+	if target.Node != nil && target.Node.ResourceVersion != "" {
+		nodeNamePtr = &target.Node.Name
+	}
+
 	// TODO add control plane label
 
 	// create remediation CR
-	var nodeNamePtr *string
-	nodeName := ""
-	if target.Node != nil && target.Node.ResourceVersion != "" {
-		nodeNamePtr = &target.Node.Name
-		nodeName = target.Node.Name
-	}
-
-	remediationCR, err := rm.GenerateRemediationCRForMachine(target.Machine, target.MHC, template, nodeName)
+	remediationCR, err := rm.GenerateRemediationCRForMachine(target.Machine, target.MHC, template, pointer.StringDeref(nodeNamePtr, ""))
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate remediation CR")
 	}

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -2283,7 +2283,7 @@ func newRemediationCRForNHC(nodeName string, nhc *v1alpha1.NodeHealthCheck) *uns
 		Name:       nhc.Name,
 		UID:        nhc.UID,
 	}
-	return newRemediationCR(nodeName, templateRef, owner)
+	return newRemediationCR(nodeName, nodeName, templateRef, owner)
 }
 
 func newNodeHealthCheck() *v1alpha1.NodeHealthCheck {

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 	GenerateRemediationCRBase(gvk schema.GroupVersionKind) *unstructured.Unstructured
 	GenerateRemediationCRBaseNamed(gvk schema.GroupVersionKind, namespace string, name string) *unstructured.Unstructured
 	GenerateRemediationCRForNode(node *corev1.Node, owner client.Object, template *unstructured.Unstructured) (*unstructured.Unstructured, error)
-	GenerateRemediationCRForMachine(machine *machinev1beta1.Machine, owner client.Object, template *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	GenerateRemediationCRForMachine(machine *machinev1beta1.Machine, owner client.Object, template *unstructured.Unstructured, nodeName string) (*unstructured.Unstructured, error)
 	CreateRemediationCR(remediationCR *unstructured.Unstructured, owner client.Object, nodeName *string, currentRemediationDuration, previousRemediationsDuration time.Duration) (bool, *time.Duration, *unstructured.Unstructured, error)
 	DeleteRemediationCR(remediationCR *unstructured.Unstructured, owner client.Object) (bool, error)
 	UpdateRemediationCR(remediationCR *unstructured.Unstructured) error
@@ -98,10 +98,10 @@ func (m *manager) GenerateRemediationCRForNode(node *corev1.Node, owner client.O
 		}
 	}
 
-	return m.generateRemediationCR(node.GetName(), nhcOwnerRef, machineOwnerRef, template)
+	return m.generateRemediationCR(node.GetName(), node.GetName(), nhcOwnerRef, machineOwnerRef, template)
 }
 
-func (m *manager) GenerateRemediationCRForMachine(machine *machinev1beta1.Machine, owner client.Object, template *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (m *manager) GenerateRemediationCRForMachine(machine *machinev1beta1.Machine, owner client.Object, template *unstructured.Unstructured, nodeName string) (*unstructured.Unstructured, error) {
 
 	mhcOwnerRef := createOwnerRef(owner)
 
@@ -116,10 +116,10 @@ func (m *manager) GenerateRemediationCRForMachine(machine *machinev1beta1.Machin
 		// So it can be ignored here.
 	}
 
-	return m.generateRemediationCR(machine.GetName(), mhcOwnerRef, machineOwnerRef, template)
+	return m.generateRemediationCR(machine.GetName(), nodeName, mhcOwnerRef, machineOwnerRef, template)
 }
 
-func (m *manager) generateRemediationCR(name string, healthCheckOwnerRef *metav1.OwnerReference, machineOwnerRef *metav1.OwnerReference, template *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (m *manager) generateRemediationCR(name string, nodeName string, healthCheckOwnerRef *metav1.OwnerReference, machineOwnerRef *metav1.OwnerReference, template *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 
 	remediationCR := m.GenerateRemediationCRBase(template.GroupVersionKind())
 
@@ -127,12 +127,13 @@ func (m *manager) generateRemediationCR(name string, healthCheckOwnerRef *metav1
 	templateSpec, _, _ := unstructured.NestedMap(template.Object, "spec", "template", "spec")
 	unstructured.SetNestedField(remediationCR.Object, templateSpec, "spec")
 
-	if annotations.HasMultipleTemplatesAnnotation(template) {
+	isMHCRemediation := name != nodeName
+	if annotations.HasMultipleTemplatesAnnotation(template) && !isMHCRemediation {
 		remediationCR.SetGenerateName(fmt.Sprintf("%s-", name))
 	} else {
 		remediationCR.SetName(name)
 	}
-	remediationCR.SetAnnotations(map[string]string{commonannotations.NodeNameAnnotation: name, annotations.TemplateNameAnnotation: template.GetName()})
+	remediationCR.SetAnnotations(map[string]string{commonannotations.NodeNameAnnotation: nodeName, annotations.TemplateNameAnnotation: template.GetName()})
 
 	remediationCR.SetNamespace(template.GetNamespace())
 	remediationCR.SetResourceVersion("")

--- a/controllers/resources/manager.go
+++ b/controllers/resources/manager.go
@@ -127,6 +127,7 @@ func (m *manager) generateRemediationCR(name string, nodeName string, healthChec
 	templateSpec, _, _ := unstructured.NestedMap(template.Object, "spec", "template", "spec")
 	unstructured.SetNestedField(remediationCR.Object, templateSpec, "spec")
 
+	// Multiple same kind templates are never supported for MHC, and remediators are not expected to handle generated names in this case, even if they do for NHC.
 	isMHCRemediation := name != nodeName
 	if annotations.HasMultipleTemplatesAnnotation(template) && !isMHCRemediation {
 		remediationCR.SetGenerateName(fmt.Sprintf("%s-", name))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -402,7 +402,7 @@ func newTestRemediationTemplateCR(kind, namespace, name string) *unstructured.Un
 	return template
 }
 
-func newRemediationCR(nodeName string, templateRef v1.ObjectReference, owner metav1.OwnerReference) *unstructured.Unstructured {
+func newRemediationCR(name string, nodeName string, templateRef v1.ObjectReference, owner metav1.OwnerReference) *unstructured.Unstructured {
 
 	// check template if it supports multiple same kind remediation
 	// not needed (and fails for missing k8sclient) for MHC tests
@@ -423,9 +423,9 @@ func newRemediationCR(nodeName string, templateRef v1.ObjectReference, owner met
 	cr := unstructured.Unstructured{}
 	cr.SetNamespace(templateRef.Namespace)
 	if mutipleSameKindSupported {
-		cr.SetGenerateName(fmt.Sprintf("%s-", nodeName))
+		cr.SetGenerateName(fmt.Sprintf("%s-", name))
 	} else {
-		cr.SetName(nodeName)
+		cr.SetName(name)
 	}
 
 	kind := templateRef.GroupVersionKind().Kind

--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func ensureRemediationResourceExists(name string, namespace string, remediationResource schema.GroupVersionResource) func() error {
+func ensureRemediationResourceExists(nodeName string, namespace string, remediationResource schema.GroupVersionResource) func() error {
 	return func() error {
 		// The CR name doesn't always match the node name in case multiple CRs of same type for the same node are supported
 		// So list all, and look for the node name in the annotation
@@ -25,7 +25,7 @@ func ensureRemediationResourceExists(name string, namespace string, remediationR
 			return err
 		}
 		for _, cr := range list.Items {
-			if nodeName, exists := cr.GetAnnotations()[commonannotations.NodeNameAnnotation]; exists && nodeName == name {
+			if annotationNodeName, exists := cr.GetAnnotations()[commonannotations.NodeNameAnnotation]; exists && annotationNodeName == nodeName {
 				log.Info("found remediation resource")
 				return nil
 			}

--- a/e2e/mhc_e2e_test.go
+++ b/e2e/mhc_e2e_test.go
@@ -31,7 +31,6 @@ const (
 
 var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 	var nodeUnderTest *v1.Node
-	var machineNameUnderTest string
 	var mhc *v1beta1.MachineHealthCheck
 	var workers *v1.NodeList
 	var leaseName string
@@ -84,7 +83,7 @@ var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 			nodeUnderTest = &workers.Items[0]
 
 			var err error
-			_, machineNameUnderTest, err = controllerutils.GetMachineNamespaceName(nodeUnderTest)
+			_, _, err = controllerutils.GetMachineNamespaceName(nodeUnderTest)
 			Expect(err).ToNot(HaveOccurred(), "failed to get machine name from node")
 
 			leaseName = fmt.Sprintf("%s-%s", "node", nodeUnderTest.Name)
@@ -126,7 +125,7 @@ var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 				By("ensuring remediation CR exists")
 				waitTime := nodeUnhealthyTime.Add(unhealthyConditionDuration + 3*time.Second).Sub(time.Now())
 				Eventually(
-					ensureRemediationResourceExists(machineNameUnderTest, mhcNamespace, remediationGVR), waitTime, "500ms").
+					ensureRemediationResourceExists(nodeUnderTest.Name, mhcNamespace, remediationGVR), waitTime, "500ms").
 					Should(Succeed())
 
 				By("ensuring lease exist")


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
When a CR is created by MHC it's not deleted by the remediator (SNR) in case the remediator supports multiple templates.
The reason is that when MHC creates the CR it creates a generated name for the CR which does not match the machine name.
When the same apply for node base remediation the additional (node name and template name) info is stored in annotations on the CR, but for machine based remediation the remediator doesn't access those annotations.

#### Changes made
- When creating an MHC remediation CR using the machine name and not generated name.
- Multiple support annotation "NodeName" will now hold the correct node name (instead of the machine name) or empty value in case there is an issue getting the node name.


#### Which issue(s) this PR fixes
[ECOPROJECT-2077](https://issues.redhat.com//browse/ECOPROJECT-2077)


#### Test plan
Added a regression test

This is blocked by  [ECOPROJECT-2187](https://issues.redhat.com//browse/ECOPROJECT-2187)
Context:
- this PR fixes an issue (MHC  didn't work for remediators which support multiple-same-kind remediation)
- but it also uncovers another issue: MHC isn't watching remediation CRs, so it doesn't delete the node lease when the finalizer on a remediation CR is removed
- because of the latter, e2e test on the PR can't get green (see 4.16 test), so this PR can't be merged without the watch issue being fixed

