### PR TITLE
Check control plane topology

### DIFF
--- a/api/v1alpha1/nodehealthcheck_webhook_test.go
+++ b/api/v1alpha1/nodehealthcheck_webhook_test.go
@@ -21,7 +21,7 @@ var _ = Describe("NodeHealthCheck Validation", func() {
 	var mockValidatorClient = &mockClient{
 		listFunc: func(context.Context, client.ObjectList, ...client.ListOption) error { return nil },
 	}
-	var validator = &customValidator{mockValidatorClient}
+	var validator = &customValidator{mockValidatorClient, testCaps}
 	Context("Creating or updating a NHC", func() {
 
 		var nhc *NodeHealthCheck
@@ -198,6 +198,18 @@ var _ = Describe("NodeHealthCheck Validation", func() {
 					})
 				})
 
+			})
+		})
+
+		Context("with unsupported control plane topology", func() {
+			BeforeEach(func() {
+				testCaps.IsSupportedControlPlaneTopology = false
+			})
+			AfterEach(func() {
+				testCaps.IsSupportedControlPlaneTopology = true
+			})
+			It("should be denied", func() {
+				Expect(validator.validate(context.Background(), nhc)).To(MatchError(ContainSubstring(unsupportedCpTopologyError)))
 			})
 		})
 	})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -38,6 +38,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -48,6 +50,12 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
+
+var testCaps = &cluster.Capabilities{
+	IsOnOpenshift:                   true,
+	HasMachineAPI:                   true,
+	IsSupportedControlPlaneTopology: true,
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -103,7 +111,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&NodeHealthCheck{}).SetupWebhookWithManager(mgr)
+	err = (&NodeHealthCheck{}).SetupWebhookWithManager(mgr, testCaps)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -280,6 +280,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - console.openshift.io
           resources:
           - consoleplugins

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins

--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -1,16 +1,23 @@
 package cluster
 
 import (
+	"context"
+
+	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 type Capabilities struct {
-	IsOnOpenshift, HasMachineAPI bool
+	IsOnOpenshift, HasMachineAPI, IsSupportedControlPlaneTopology bool
 }
 
-func NewCapabilities(config *rest.Config) (Capabilities, error) {
+func NewCapabilities(config *rest.Config, reader client.Reader, logger logr.Logger, ctx context.Context) (Capabilities, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return Capabilities{}, err
@@ -25,6 +32,8 @@ func NewCapabilities(config *rest.Config) (Capabilities, error) {
 	machineAPIGroup := schema.GroupVersion{Group: "machine.openshift.io", Version: "v1"}
 
 	caps := Capabilities{}
+
+	// check API groups for OCP and MachineAPI groups
 	for _, apiGroup := range apiGroups.Groups {
 		for _, supportedVersion := range apiGroup.Versions {
 			if supportedVersion.GroupVersion == ocpKind.GroupVersion().String() {
@@ -38,5 +47,32 @@ func NewCapabilities(config *rest.Config) (Capabilities, error) {
 			}
 		}
 	}
+
+	// check topology, default to true on non-openshift clusters
+	caps.IsSupportedControlPlaneTopology = true
+	if caps.IsOnOpenshift {
+		infra := &configv1.Infrastructure{}
+		err = reader.Get(ctx, client.ObjectKey{Name: "cluster"}, infra)
+		if err != nil {
+			return Capabilities{}, err
+		}
+		cpTopology := infra.Status.ControlPlaneTopology
+
+		// add new supported topology modes here if needed
+		// don't allow new topologies by default, because they might implement their own fencing logic, which can conflict with this operator
+		// see https://github.com/openshift/api/blob/c1fdeb0788c16659238d93ec45ce2e798c14eb88/config/v1/types_infrastructure.go#L129-L147
+		if cpTopology == configv1.HighlyAvailableTopologyMode ||
+			cpTopology == configv1.SingleReplicaTopologyMode ||
+			cpTopology == configv1.ExternalTopologyMode {
+
+			logger.Info("supported control plane topology", "topology", cpTopology)
+			caps.IsSupportedControlPlaneTopology = true
+
+		} else {
+			logger.Info("unsupported control plane topology", "topology", cpTopology)
+			caps.IsSupportedControlPlaneTopology = false
+		}
+	}
+
 	return caps, nil
 }

--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -17,6 +17,12 @@ type Capabilities struct {
 	IsOnOpenshift, HasMachineAPI, IsSupportedControlPlaneTopology bool
 }
 
+//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
+
+// NewCapabilities returns a Capabilities struct with the following fields:
+// - IsOnOpenshift: true if the cluster is an OpenShift cluster
+// - HasMachineAPI: true if the cluster has the Machine API installed
+// - IsSupportedControlPlaneTopology: true if the cluster has a supported control plane topology
 func NewCapabilities(config *rest.Config, reader client.Reader, logger logr.Logger, ctx context.Context) (Capabilities, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {


### PR DESCRIPTION
#### Why we need this PR
There might be clusters which handle fencing on their own in future.
Disallow NHC configs in these cases, in order to prevent fencing conflicts. 

#### Changes made
- Added control plane topology check to cluster capabilities
- Use capabilities in admission webhook

#### Which issue(s) this PR fixes
[ECOPROJECT-2395](https://issues.redhat.com//browse/ECOPROJECT-2395)

#### Test plan
- added unit test for admission webhook
- existing e2e tests ensure we don't add regression