### PR TITLE
Support hcp upgrade

### DIFF
--- a/controllers/cluster/upgrade_checker.go
+++ b/controllers/cluster/upgrade_checker.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-logr/logr"
 	gerrors "github.com/pkg/errors"
@@ -14,10 +13,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	clusterversion "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
-
-var unsupportedUpgradeCheckerErr = errors.New(
-	"the cluster doesn't have any upgrade state representation." +
-		" Currently only OpenShift/OKD is supported")
 
 // UpgradeChecker checks if the cluster is currently under upgrade.
 // error should be thrown if it can't reliably determine if it's under upgrade or not.

--- a/controllers/cluster/upgrade_checker.go
+++ b/controllers/cluster/upgrade_checker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	gerrors "github.com/pkg/errors"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -14,12 +15,19 @@ import (
 	clusterversion "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
 
+const (
+	// currentMachineConfigAnnotationKey is used to fetch current targetConfigVersionHash
+	currentMachineConfigAnnotationKey = "machineconfiguration.openshift.io/currentConfig"
+	// desiredMachineConfigAnnotationKey is used to indicate the version a node should be updating to
+	desiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
+)
+
 // UpgradeChecker checks if the cluster is currently under upgrade.
 // error should be thrown if it can't reliably determine if it's under upgrade or not.
 type UpgradeChecker interface {
 	// Check if the cluster is currently under upgrade.
 	// error should be thrown if it can't reliably determine if it's under upgrade or not.
-	Check() (bool, error)
+	Check(nodesToBeRemediated []corev1.Node) (bool, error)
 }
 
 type openshiftClusterUpgradeStatusChecker struct {
@@ -31,7 +39,11 @@ type openshiftClusterUpgradeStatusChecker struct {
 // force implementation of interface
 var _ UpgradeChecker = &openshiftClusterUpgradeStatusChecker{}
 
-func (o *openshiftClusterUpgradeStatusChecker) Check() (bool, error) {
+func (o *openshiftClusterUpgradeStatusChecker) Check(nodesToBeRemediated []corev1.Node) (bool, error) {
+	if o.isNodeUpgrading(nodesToBeRemediated) {
+		return true, nil
+	}
+
 	cvs, err := o.clusterVersionsClient.List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return false, gerrors.Wrap(err, "failed to check for Openshift cluster upgrade status")
@@ -47,13 +59,27 @@ func (o *openshiftClusterUpgradeStatusChecker) Check() (bool, error) {
 	return false, nil
 }
 
+func (o *openshiftClusterUpgradeStatusChecker) isNodeUpgrading(nodesToBeRemediated []corev1.Node) bool {
+	// We can identify an HCP (Hosted Control Plane) cluster upgrade by checking annotations of the CP node.
+	for _, node := range nodesToBeRemediated {
+		if len(node.Annotations) == 0 || len(node.Annotations[desiredMachineConfigAnnotationKey]) == 0 {
+			continue
+		}
+
+		if node.Annotations[currentMachineConfigAnnotationKey] != node.Annotations[desiredMachineConfigAnnotationKey] {
+			return true
+		}
+	}
+	return false
+}
+
 type noopClusterUpgradeStatusChecker struct {
 }
 
 // force implementation of interface
 var _ UpgradeChecker = &noopClusterUpgradeStatusChecker{}
 
-func (n *noopClusterUpgradeStatusChecker) Check() (bool, error) {
+func (n *noopClusterUpgradeStatusChecker) Check([]corev1.Node) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
This feature aims to address the current limitations of NodeHealthCheck (NHC) in Hosted Control Planes (HCP). While NHC is operational in HCP, it lacks the ability to block or pause upgrades when nodes are unhealthy. 

#### Changes made
In addition to previous checks,  NHC will also compare "machineconfiguration.openshift.io/currentConfig" and  "machineconfiguration.openshift.io/desiredConfig" on the CP node  to decide whether an update is in progress.


#### Which issue(s) this PR fixes
[OCPSTRAT-1828](https://issues.redhat.com//browse/OCPSTRAT-1828)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
