### PR TITLE
MHC does not watch remediation

### DIFF
--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -2425,6 +2425,7 @@ func newFakeReconcilerWithCustomRecorder(recorder record.EventRecorder, initObje
 		FeatureGates: &featuregates.FakeAccessor{
 			IsMaoMhcDisabled: true,
 		},
+		WatchManager: &fakeWatchManager{},
 	}
 }
 

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -86,7 +86,7 @@ type NodeHealthCheckReconciler struct {
 	Capabilities                cluster.Capabilities
 	MHCEvents                   chan event.GenericEvent
 	controller                  controller.Controller
-	WatchManager                *resources.WatchManager
+	WatchManager                resources.WatchManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -117,7 +117,7 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	r.WatchManager.Controller = controller
+	r.WatchManager.SetController(controller)
 	return nil
 }
 

--- a/controllers/nodehealthcheck_controller.go
+++ b/controllers/nodehealthcheck_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -45,7 +44,6 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -88,9 +86,7 @@ type NodeHealthCheckReconciler struct {
 	Capabilities                cluster.Capabilities
 	MHCEvents                   chan event.GenericEvent
 	controller                  controller.Controller
-	watches                     map[string]struct{}
-	watchesLock                 *sync.Mutex
-	cache                       cache.Cache
+	WatchManager                *resources.WatchManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -121,10 +117,7 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	r.controller = controller
-	r.watches = make(map[string]struct{})
-	r.watchesLock = &sync.Mutex{}
-	r.cache = mgr.GetCache()
+	r.WatchManager.Controller = controller
 	return nil
 }
 
@@ -234,7 +227,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// add watches for template and remediation CRs
-	if err = r.addWatches(resourceManager, nhc); err != nil {
+	if err = r.WatchManager.AddWatchesNhc(resourceManager, nhc); err != nil {
 		return result, err
 	}
 
@@ -810,91 +803,6 @@ func (r *NodeHealthCheckReconciler) alertOldRemediationCR(remediationCR *unstruc
 	}
 	return isSendAlert, nextReconcile
 
-}
-
-func (r *NodeHealthCheckReconciler) addWatches(rm resources.Manager, nhc *remediationv1alpha1.NodeHealthCheck) error {
-
-	addWatches := func(ref v1.ObjectReference) error {
-		template := rm.GenerateTemplate(&ref)
-		if err := r.addRemediationTemplateCRWatch(template); err != nil {
-			r.Log.Error(err, "failed to add watch for template CR", "kind", template.GetKind())
-			return err
-		}
-		rem := rm.GenerateRemediationCRBase(template.GroupVersionKind())
-		if err := r.addRemediationCRWatch(rem); err != nil {
-			r.Log.Error(err, "failed to add watch for remediation CR", "kind", rem.GetKind())
-			return err
-		}
-		return nil
-	}
-
-	if nhc.Spec.RemediationTemplate != nil {
-		if err := addWatches(*nhc.Spec.RemediationTemplate); err != nil {
-			return err
-		}
-	} else {
-		for _, rem := range nhc.Spec.EscalatingRemediations {
-			if err := addWatches(rem.RemediationTemplate); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (r *NodeHealthCheckReconciler) addRemediationCRWatch(remediationCR *unstructured.Unstructured) error {
-	r.watchesLock.Lock()
-	defer r.watchesLock.Unlock()
-
-	key := remediationCR.GroupVersionKind().String()
-	if _, exists := r.watches[key]; exists {
-		// already watching
-		return nil
-	}
-	if err := r.controller.Watch(
-		source.Kind(r.cache, remediationCR),
-		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationCRMapperFunc(r.Log)),
-		predicate.Funcs{
-			// we are just interested in update and delete events for now
-			// remediation CR update: watch conditions
-			// remediation CR deletion: clean up
-			CreateFunc:  func(_ event.CreateEvent) bool { return false },
-			GenericFunc: func(_ event.GenericEvent) bool { return false },
-		},
-	); err != nil {
-		return err
-	}
-	r.watches[key] = struct{}{}
-	r.Log.Info("added watch for remediation CRs", "kind", remediationCR.GetKind())
-	return nil
-}
-
-func (r *NodeHealthCheckReconciler) addRemediationTemplateCRWatch(templateCR *unstructured.Unstructured) error {
-	r.watchesLock.Lock()
-	defer r.watchesLock.Unlock()
-
-	key := templateCR.GroupVersionKind().String()
-	if _, exists := r.watches[key]; exists {
-		// already watching
-		return nil
-	}
-	if err := r.controller.Watch(
-		source.Kind(r.cache, templateCR),
-		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationTemplateCRMapperFunc(r.Client, r.Log)),
-		predicate.Funcs{
-			// we are just interested in update and delete events for now
-			// template CR updates: validate
-			// template CR deletion: update NHC status
-			CreateFunc:  func(_ event.CreateEvent) bool { return false },
-			GenericFunc: func(_ event.GenericEvent) bool { return false },
-		},
-	); err != nil {
-		return err
-	}
-	r.watches[key] = struct{}{}
-	r.Log.Info("added watch for remediation template CRs", "kind", templateCR.GetKind())
-	return nil
 }
 
 func (r *NodeHealthCheckReconciler) isNodeRemediationExcluded(node *v1.Node) bool {

--- a/controllers/resources/watch.go
+++ b/controllers/resources/watch.go
@@ -1,0 +1,116 @@
+package resources
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/medik8s/node-healthcheck-operator/api/v1alpha1"
+	"github.com/medik8s/node-healthcheck-operator/controllers/utils"
+)
+
+type WatchManager struct {
+	Client     client.Client
+	Log        logr.Logger
+	Controller controller.Controller
+	Cache      cache.Cache
+	Watches    map[string]struct{}
+	Lock       *sync.Mutex
+}
+
+// NewWatchManager creates a new instance of WatchManager.
+func NewWatchManager(c client.Client, log logr.Logger, cache cache.Cache) *WatchManager {
+	return &WatchManager{
+		Client:  c,
+		Log:     log,
+		Cache:   cache,
+		Watches: make(map[string]struct{}),
+		Lock:    &sync.Mutex{},
+	}
+}
+
+func (wm *WatchManager) AddWatchesNhc(rm Manager, nhc *v1alpha1.NodeHealthCheck) error {
+	var remediationsToWatch []v1.ObjectReference
+	//aggregate all templates to watch
+	if nhc.Spec.RemediationTemplate != nil {
+		remediationsToWatch = append(remediationsToWatch, *nhc.Spec.RemediationTemplate)
+	}
+	for _, escalatingRemediation := range nhc.Spec.EscalatingRemediations {
+		remediationsToWatch = append(remediationsToWatch, escalatingRemediation.RemediationTemplate)
+	}
+	return wm.addWatches(rm, remediationsToWatch)
+}
+
+func (wm *WatchManager) addWatches(rm Manager, templates []v1.ObjectReference) error {
+	for _, ref := range templates {
+		template := rm.GenerateTemplate(&ref)
+		if err := wm.addRemediationTemplateCRWatch(template); err != nil {
+			wm.Log.Error(err, "failed to add watch for template CR", "kind", template.GetKind())
+			return err
+		}
+		rem := rm.GenerateRemediationCRBase(template.GroupVersionKind())
+		if err := wm.addRemediationCRWatch(rem); err != nil {
+			wm.Log.Error(err, "failed to add watch for remediation CR", "kind", rem.GetKind())
+			return err
+		}
+	}
+	return nil
+}
+
+func (wm *WatchManager) addRemediationTemplateCRWatch(templateCR *unstructured.Unstructured) error {
+	wm.Lock.Lock()
+	defer wm.Lock.Unlock()
+
+	key := templateCR.GroupVersionKind().String()
+	if _, exists := wm.Watches[key]; exists {
+		return nil
+	}
+
+	if err := wm.Controller.Watch(
+		source.Kind(wm.Cache, templateCR),
+		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationTemplateCRMapperFunc(wm.Client, wm.Log)),
+		predicate.Funcs{
+			CreateFunc:  func(_ event.CreateEvent) bool { return false },
+			GenericFunc: func(_ event.GenericEvent) bool { return false },
+		},
+	); err != nil {
+		return err
+	}
+	wm.Watches[key] = struct{}{}
+	wm.Log.Info("added watch for remediation template CRs", "kind", templateCR.GetKind())
+	return nil
+}
+
+func (wm *WatchManager) addRemediationCRWatch(remediationCR *unstructured.Unstructured) error {
+	wm.Lock.Lock()
+	defer wm.Lock.Unlock()
+
+	key := remediationCR.GroupVersionKind().String()
+	if _, exists := wm.Watches[key]; exists {
+		return nil
+	}
+
+	if err := wm.Controller.Watch(
+		source.Kind(wm.Cache, remediationCR),
+		handler.EnqueueRequestsFromMapFunc(utils.NHCByRemediationCRMapperFunc(wm.Log)),
+		predicate.Funcs{
+			CreateFunc:  func(_ event.CreateEvent) bool { return false },
+			GenericFunc: func(_ event.GenericEvent) bool { return false },
+		},
+	); err != nil {
+		return err
+	}
+	wm.Watches[key] = struct{}{}
+	wm.Log.Info("added watch for remediation CRs", "kind", remediationCR.GetKind())
+	return nil
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/medik8s/node-healthcheck-operator/controllers/cluster"
 	"github.com/medik8s/node-healthcheck-operator/controllers/featuregates"
 	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
+	"github.com/medik8s/node-healthcheck-operator/controllers/resources"
 	"github.com/medik8s/node-healthcheck-operator/controllers/utils/annotations"
 )
 
@@ -240,6 +241,7 @@ var _ = BeforeSuite(func() {
 		return time.Now()
 	}
 
+	watchManager := resources.NewWatchManager(k8sManager.GetClient(), ctrl.Log.WithName("controllers").WithName("NodeHealthCheck").WithName("WatchManager"), k8sManager.GetCache())
 	mhcEvents := make(chan event.GenericEvent)
 	fakeRecorder = record.NewFakeRecorder(1000)
 	ocpUpgradeChecker, _ = cluster.NewClusterUpgradeStatusChecker(k8sManager, cluster.Capabilities{IsOnOpenshift: true})
@@ -251,6 +253,7 @@ var _ = BeforeSuite(func() {
 		MHCChecker:                  mhcChecker,
 		MHCEvents:                   mhcEvents,
 		Capabilities:                caps,
+		WatchManager:                watchManager,
 	}
 	err = nhcReconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/utils/mapper.go
+++ b/controllers/utils/mapper.go
@@ -25,6 +25,14 @@ const (
 	MachineNodeNameIndex = "machineNodeNameIndex"
 )
 
+// WatchType is used to differentiate watch CR logic between NHC and MHC.
+type WatchType string
+
+const (
+	NHC WatchType = "NHC"
+	MHC WatchType = "MHC"
+)
+
 // NHCByNodeMapperFunc return the Node-to-NHC mapper function
 func NHCByNodeMapperFunc(c client.Client, logger logr.Logger) handler.MapFunc {
 	// This closure is meant to fetch all NHC to fill the reconcile queue.
@@ -86,22 +94,31 @@ func NHCByMHCEventMapperFunc(c client.Client, logger logr.Logger) handler.MapFun
 	return delegate
 }
 
-// NHCByRemediationCRMapperFunc return the RemediationCR-to-NHC mapper function
-func NHCByRemediationCRMapperFunc(logger logr.Logger) handler.MapFunc {
+// RemediationCRMapperFunc return the RemediationCR-to-NHC/MHC mapper function
+func RemediationCRMapperFunc(logger logr.Logger, watchType WatchType) handler.MapFunc {
 	// This closure is meant to get the NHC for the given remediation CR
 	delegate := func(ctx context.Context, o client.Object) []reconcile.Request {
 		requests := make([]reconcile.Request, 0)
 		for _, owner := range o.GetOwnerReferences() {
-			if owner.Kind == "NodeHealthCheck" && owner.APIVersion == remediationv1alpha1.GroupVersion.String() {
-				logger.Info("mapper: found NHC for remediation CR", "NHC Name", owner.Name, "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
+			logger.Info("Request info", "owner ref", owner)
+			if isCrNeedWatching(owner, watchType) {
+				logger.Info(fmt.Sprintf("mapper: found %s for remediation CR", watchType), fmt.Sprintf("%s Name", watchType), owner.Name, "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: owner.Name}})
 				return requests
 			}
 		}
-		logger.Info("mapper: didn't find NHC for remediation CR", "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
+		logger.Info(fmt.Sprintf("mapper: didn't find %s for remediation CR", watchType), "Remediation CR Name", o.GetName(), "Remediation CR Kind", o.GetObjectKind().GroupVersionKind().Kind)
 		return requests
 	}
 	return delegate
+}
+
+func isCrNeedWatching(owner metav1.OwnerReference, watchType WatchType) bool {
+	if watchType == NHC {
+		return owner.Kind == "NodeHealthCheck" && owner.APIVersion == remediationv1alpha1.GroupVersion.String()
+	} else {
+		return owner.Kind == "Machine" && owner.APIVersion == machinev1beta1.GroupVersion.String()
+	}
 }
 
 // NHCByRemediationTemplateCRMapperFunc return the RemediationTemplateCR-to-NHC mapper function

--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -34,3 +34,28 @@ func ensureRemediationResourceExists(nodeName string, namespace string, remediat
 		return fmt.Errorf("not found")
 	}
 }
+
+func ensureRemediationResourceDoesNotExist(nodeName string, namespace string, remediationResource schema.GroupVersionResource) func() error {
+	return func() error {
+		// The CR name doesn't always match the node name in case multiple CRs of same type for the same node are supported
+		// So list all, and look for the node name in the annotation
+		list, err := dynamicClient.Resource(remediationResource).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Info("verified remediation resource does not exist")
+				return nil
+			} else {
+				log.Error(err, "failed to get remediation resource")
+			}
+			return err
+		}
+		for _, cr := range list.Items {
+			if annotationNodeName, exists := cr.GetAnnotations()[commonannotations.NodeNameAnnotation]; exists && annotationNodeName == nodeName {
+				log.Info("remediation resource still exist")
+				return fmt.Errorf("remediation exist")
+			}
+		}
+		log.Info("verified remediation resource does not exist")
+		return nil
+	}
+}

--- a/e2e/mhc_e2e_test.go
+++ b/e2e/mhc_e2e_test.go
@@ -144,17 +144,22 @@ var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 				By("waiting for healthy node condition")
 				utils.WaitForNodeHealthyCondition(k8sClient, nodeUnderTest, v1.ConditionTrue)
 
-				By("waiting for remediation CR deletion, else cleanup fails")
+				By("waiting for triggering remediation CR deletion, else cleanup fails")
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(mhc), mhc)).To(Succeed())
 					g.Expect(*mhc.Status.CurrentHealthy).To(BeNumerically("==", len(workers.Items)))
 				}, "5m", "5s").Should(Succeed(), "CR not deleted")
 
+				By("waiting for CR deletion (after finilizers are removed by snr) in order to trigger lease removal")
+				Eventually(
+					ensureRemediationResourceDoesNotExist(nodeUnderTest.Name, mhcNamespace, remediationGVR), "5m", "5s").
+					Should(Succeed())
+
 				By("ensuring lease removed")
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				}, "1m", "5s").Should(Succeed(), "lease not deleted")
+				}, "2m", "5s").Should(Succeed(), "lease not deleted")
 
 			})
 		})

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	watchManager := resources.NewWatchManager(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("NodeHealthCheck").WithName("WatchManager"), mgr.GetCache())
+	nhcWatchManager := resources.NewWatchManager(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("NodeHealthCheck").WithName("WatchManager"), mgr.GetCache())
 	if err := (&controllers.NodeHealthCheckReconciler{
 		Client:                      mgr.GetClient(),
 		Log:                         ctrl.Log.WithName("controllers").WithName("NodeHealthCheck"),
@@ -176,7 +176,7 @@ func main() {
 		MHCChecker:                  mhcChecker,
 		Capabilities:                caps,
 		MHCEvents:                   mhcEvents,
-		WatchManager:                watchManager,
+		WatchManager:                nhcWatchManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeHealthCheck")
 		os.Exit(1)
@@ -189,7 +189,7 @@ func main() {
 			setupLog.Error(err, "failed to add feature gate accessor to the manager")
 			os.Exit(1)
 		}
-
+		mhcWatchManager := resources.NewWatchManager(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("MachineHealthCheck").WithName("WatchManager"), mgr.GetCache())
 		if err := (&controllers.MachineHealthCheckReconciler{
 			Client:                         mgr.GetClient(),
 			Log:                            ctrl.Log.WithName("controllers").WithName("MachineHealthCheck"),
@@ -198,6 +198,7 @@ func main() {
 			MHCChecker:                     mhcChecker,
 			FeatureGateMHCControllerEvents: featureGateMHCControllerDisabledEvents,
 			FeatureGates:                   featureGateAccessor,
+			WatchManager:                   mhcWatchManager,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachineHealthCheck")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/medik8s/node-healthcheck-operator/controllers/featuregates"
 	"github.com/medik8s/node-healthcheck-operator/controllers/initializer"
 	"github.com/medik8s/node-healthcheck-operator/controllers/mhc"
+	"github.com/medik8s/node-healthcheck-operator/controllers/resources"
 	"github.com/medik8s/node-healthcheck-operator/metrics"
 	"github.com/medik8s/node-healthcheck-operator/version"
 )
@@ -166,6 +167,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	watchManager := resources.NewWatchManager(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("NodeHealthCheck").WithName("WatchManager"), mgr.GetCache())
 	if err := (&controllers.NodeHealthCheckReconciler{
 		Client:                      mgr.GetClient(),
 		Log:                         ctrl.Log.WithName("controllers").WithName("NodeHealthCheck"),
@@ -174,6 +176,7 @@ func main() {
 		MHCChecker:                  mhcChecker,
 		Capabilities:                caps,
 		MHCEvents:                   mhcEvents,
+		WatchManager:                watchManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeHealthCheck")
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
MHC does not watch the remediation CR, which in turn will cause it to miss the remediator (for example) removing the finalizer and will not trigger the lease removal and the deletion of the CR.
This issue also causes the CI e2e tests to fail (or at least be extremely flaky)

#### Changes made
Extracted NHC watch remediation/template to a new component
Use this component both by NHC and MHC in order to prevent code duplication

#### Which issue(s) this PR fixes
[ECOPROJECT-2187](https://issues.redhat.com//browse/ECOPROJECT-2187)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
