### PR TITLE
Fix a flaky test

### DIFF
--- a/e2e/mhc_e2e_test.go
+++ b/e2e/mhc_e2e_test.go
@@ -159,7 +159,7 @@ var _ = Describe("e2e - MHC", Label("MHC", labelOcpOnlyValue), func() {
 				Eventually(func(g Gomega) {
 					err := k8sClient.Get(context.Background(), ctrl.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				}, "2m", "5s").Should(Succeed(), "lease not deleted")
+				}, "8m", "5s").Should(Succeed(), "lease not deleted")
 
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
Fixing a flaky e2e test as a followup for this [comment](https://github.com/medik8s/node-healthcheck-operator/pull/364#issuecomment-2837944572)  


#### Changes made
Increase timeout for lease removal


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
