### PR TITLE
Allow HighlyAvailableArbiter control plane topology

### DIFF
--- a/controllers/cluster/capabilities.go
+++ b/controllers/cluster/capabilities.go
@@ -69,6 +69,10 @@ func NewCapabilities(config *rest.Config, reader client.Reader, logger logr.Logg
 		// see https://github.com/openshift/api/blob/c1fdeb0788c16659238d93ec45ce2e798c14eb88/config/v1/types_infrastructure.go#L129-L147
 		if cpTopology == configv1.HighlyAvailableTopologyMode ||
 			cpTopology == configv1.SingleReplicaTopologyMode ||
+			// quick fix without updating openshift/api dependency, it would need too many other updates
+			// see https://github.com/openshift/api/blob/017e9dd0276e4ed0242a759dffd419d728337876/config/v1/types_infrastructure.go#L142
+			// update to const once deps are updated
+			cpTopology == "HighlyAvailableArbiter" ||
 			cpTopology == configv1.ExternalTopologyMode {
 
 			logger.Info("supported control plane topology", "topology", cpTopology)


### PR DESCRIPTION
#### Why we need this PR

There is a new "HighlyAvailableArbiter" OCP control plane topology, and NHC should be allowed to run on such clusters

#### Changes made

- Added HighlyAvailableArbiter topology to whitelist
- openshfit/api wasn't updated (4.19 would be needed), because it would need many other dependency updates, which we don't want for now
 
#### Which issue(s) this PR fixes
[RHWA-62](https://issues.redhat.com//browse/RHWA-62)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "HighlyAvailableArbiter" control plane topology mode, expanding the range of supported cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->