### PR TITLE
Fix flaky e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ testbin/*
 *.swo
 *~
 testdata/.remediators/
+.history/*

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -172,7 +172,7 @@ var _ = BeforeSuite(func() {
 			// wait until resource exists
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(context.Background(), ctrl.ObjectKeyFromObject(obj), obj)).To(Succeed())
-			}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
+			}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 		} else {
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -58,8 +58,6 @@ if [[ -z "${OPENSHIFT_CI}" ]]; then
   exit $exitCode
 fi
 
-echo "Preparing MachineHealthCheck e2e tests"
-
 retry() {
   local retries=$1
   local wait=$2
@@ -78,6 +76,11 @@ retry() {
     sleep $wait
   done
 }
+
+echo "Waiting until cluster is healthy after NHC tests"
+retry 5 30 oc wait --for=condition=Progressing=False --timeout=2m --all clusteroperators
+
+echo "Preparing MachineHealthCheck e2e tests"
 
 echo "Pausing MachineConfigPools in order to prevent reboots after enabling feature gate"
 retry 3 5 oc patch machineconfigpool worker --type=merge --patch='{"spec":{"paused":true}}'

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -48,36 +48,6 @@ exitCode=0
 echo "Running NodeHealthCheck e2e tests"
 goTest "NHC" || exitCode=$((exitCode+1))
 
-# check if on OCP, and minimum OCP version met (4.14) for MHC tests
-MHC_MIN_OCP_MINOR=14
-
-if ! (which oc 2>/dev/null 1>&2); then
-  echo "skipping MHC test, oc binary not found"
-  exit $exitCode
-fi
-
-OCP_VERSION=$(oc version -o=json | jq -r '.openshiftVersion')
-if [[ -z ${OCP_VERSION} ]]; then
-  echo "skipping MHC test, not on OCP"
-  exit $exitCode
-fi
-
-# sed explained:
-# s/ replace
-# .  single char (major version)
-# \. literal "."
-# \( start group
-# .. two chars (the minor version we want to get)
-# \) close group
-# \. literal "."
-# .* all remaining chars
-# /\1/ replace all with first group
-OCP_MINOR=$(echo ${OCP_VERSION} | sed 's/.\.\(..\)\..*/\1/')
-if [[ ${OCP_MINOR} -lt ${MHC_MIN_OCP_MINOR} ]]; then
-  echo "skipping MHC test on OCP version ${OCP_VERSION}, it needs 4.${MHC_MIN_OCP_MINOR} at least"
-  exit $exitCode
-fi
-
 echo "Preparing MachineHealthCheck e2e tests"
 
 echo "Pausing MachineConfigPools in order to prevent reboots after enabling feature gate"

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -53,6 +53,11 @@ if ! command -v oc &>/dev/null; then
   exit $exitCode
 fi
 
+if [[ -z "${OPENSHIFT_CI}" ]]; then
+  echo "not running in Openshift CI, skipping MHC test"
+  exit $exitCode
+fi
+
 echo "Preparing MachineHealthCheck e2e tests"
 
 retry() {


### PR DESCRIPTION
#### Why we need this PR

Commands for preparing MHC tests fail regularly which cuases flaky e2e test

#### Changes made
- wait for healty cluster
- add retry to relevant commands in e2e script
- remove OCP version check (we run on OCP 4.14+ only now)
- improve retry when creating resources in e2e suite
- update gitignore

#### Which issue(s) this PR fixes
[RHWA-100](https://issues.redhat.com//browse/RHWA-100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated file ignore settings to exclude the `.history` directory from version control.

* **Refactor**
  * Improved reliability of end-to-end test scripts by adding automatic retries to critical commands.
  * Simplified test execution by removing version checks and relying on environment variables.
  * Extended wait times and enhanced retry logic in test readiness checks to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->