### PR TITLE
WIP TEST add debugging of cluster state after NHC test

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -78,6 +78,22 @@ if [[ ${OCP_MINOR} -lt ${MHC_MIN_OCP_MINOR} ]]; then
   exit $exitCode
 fi
 
+# Loop for 10 minutes, repeating every 30 seconds.
+start_time=$(date +%s)
+while true; do
+  echo "Debug: $(date) - API check"
+
+  oc get clusterversion version -o yaml || true
+  oc get clusteroperator || true
+
+  sleep 30
+  now=$(date +%s)
+  elapsed=$((now - start_time))
+  if [[ $elapsed -ge 600 ]]; then
+    break
+  fi
+done
+
 echo "Preparing MachineHealthCheck e2e tests"
 
 echo "Pausing MachineConfigPools in order to prevent reboots after enabling feature gate"


### PR DESCRIPTION
Just debugging cluster state after NHC tests...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pre-test loop that periodically checks and displays cluster version and operator status for up to 10 minutes before running MachineHealthCheck end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->