### PR TITLE
Add podAntiAffinity to node-healthceck-controller-manager Deployment to improve HA

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -478,6 +478,21 @@ spec:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
                     weight: 1
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: app.kubernetes.io/component
+                          operator: In
+                          values:
+                          - controller-manager
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                          - node-healthcheck-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443

--- a/config/patches/affinity/kustomization.yaml
+++ b/config/patches/affinity/kustomization.yaml
@@ -4,3 +4,7 @@ patches:
 - path: node_affinity_patch.yaml
   target:
     kind: Deployment
+- path: podantiaffinity_patch.yaml
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/config/patches/affinity/podantiaffinity_patch.yaml
+++ b/config/patches/affinity/podantiaffinity_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n/a
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - controller-manager
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - node-healthcheck-operator
+                topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
#### Why we need this PR
In the current deployment configuration, multiple replicas of the node-healthcheck-controller-manager can be scheduled on the same node. This creates a single point of failure. This setup does not fully utilize the benefits of having multiple replicas. With better placement, we can use the replicas more effectively.

Changes made

#### Changes made

- Added a new patch file `podantiaffinity_patch.yaml` under config/patches/affinity/
  - Updated "config/patches/affinity/kustomization.yaml" to include the new patch
  - The patch is scoped to the `node-healthcheck-controller-manager Deployment` only by specifying `name: controller-manager` in the patch target
- Defines `podAntiAffinity` rules to prevent scheduling both replicas on the same node
  - Matches pods with:
    - `app.kubernetes.io/component: controller-manager`
    - `app.kubernetes.io/name: node-healthcheck-operator`
    - Uses topologyKey: `kubernetes.io/hostname`

#### Which issue(s) this PR fixes


#### Test plan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added pod anti-affinity to the Node Health Check Operator controller pods to prefer spreading across different nodes, improving resilience and reducing risk from node failures. No runtime behavior changes.

- Chores
  - Updated deployment patches to apply the new anti-affinity to the controller-manager deployment.
  - Refreshed operator metadata to include the scheduling preference in the published manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->