### PR TITLE
Updates to Storm recovery PR

### DIFF
--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -38,7 +38,7 @@ const (
 	ConditionTypeStormActive = "StormActive"
 	// ConditionReasonStormThresholdChange is the condition reason for a storm change from active to inactive and vice versa
 	ConditionReasonStormThresholdChange = "HealthyNodeThresholdChange"
-	// ConditionTypeStormCooldownActive is a separate condition type used to track when storm recovery cooldown delay is active.
+	// ConditionTypeStormCooldownActive is a separate condition type used to track when storm cooldown delay is active.
 	// The reason this was added as a new condition and not as a reason on top of the existing StormActive condition is because we need to track the time cooldown was initiated and LastTransitionTime is only updated when the condition status changes (True/False),
 	// By using a separate condition type, we ensure LastTransitionTime is properly set when
 	// the cooldown delay starts, which is needed for accurate requeue timing calculations.
@@ -116,13 +116,13 @@ type NodeHealthCheckSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
-	// StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+	// StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
 	// A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
 	// Sometimes this is triggered by a single root cause.
 	// When that cause is fixed, there is a risk to remediate healthy nodes:
 	// the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
 	// which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
-	// The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+	// The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 	//
 	// Expects a string of decimal numbers each with optional fraction and a unit
 	// suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"

--- a/api/v1alpha1/nodehealthcheck_types.go
+++ b/api/v1alpha1/nodehealthcheck_types.go
@@ -38,6 +38,11 @@ const (
 	ConditionTypeStormActive = "StormActive"
 	// ConditionReasonStormThresholdChange is the condition reason for a storm change from active to inactive and vice versa
 	ConditionReasonStormThresholdChange = "HealthyNodeThresholdChange"
+	// ConditionTypeStormCooldownActive is a separate condition type used to track when storm recovery cooldown delay is active.
+	// The reason this was added as a new condition and not as a reason on top of the existing StormActive condition is because we need to track the time cooldown was initiated and LastTransitionTime is only updated when the condition status changes (True/False),
+	// By using a separate condition type, we ensure LastTransitionTime is properly set when
+	// the cooldown delay starts, which is needed for accurate requeue timing calculations.
+	ConditionTypeStormCooldownActive = "StormCooldownActive"
 )
 
 // NHCPhase is the string used for NHC.Status.Phase
@@ -111,12 +116,13 @@ type NodeHealthCheckSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
-	// StormTerminationDelay introduces a configurable delay after storm recovery
-	// exit criteria are satisfied (for example, when the number of healthy nodes
-	// rises above the configured minHealthy constraint). While this
-	// delay is in effect, NHC remains in storm recovery mode and does not create
-	// new remediations. Once the delay elapses, storm recovery mode exits and normal
-	// remediation resumes.
+	// StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+	// A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+	// Sometimes this is triggered by a single root cause.
+	// When that cause is fixed, there is a risk to remediate healthy nodes:
+	// the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+	// which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+	// The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 	//
 	// Expects a string of decimal numbers each with optional fraction and a unit
 	// suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
@@ -126,7 +132,7 @@ type NodeHealthCheckSpec struct {
 	//+kubebuilder:validation:Type=string
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
-	StormTerminationDelay *metav1.Duration `json:"stormTerminationDelay,omitempty"`
+	StormCooldownDuration *metav1.Duration `json:"stormCooldownDuration,omitempty"`
 
 	// RemediationTemplate is a reference to a remediation template
 	// provided by an infrastructure provider.
@@ -286,15 +292,6 @@ type NodeHealthCheckStatus struct {
 	//+optional
 	//+operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:io.kubernetes.phase:reason"
 	Reason string `json:"reason,omitempty"`
-
-	// StormTerminationStartTime records when storm recovery mode regained the minHealthy/maxUnhealthy constraint
-	// and the storm is about to end (after NodeHealthCheckSpec.StormTerminationDelay has passed).
-	//
-	//+optional
-	//+kubebuilder:validation:Type=string
-	//+kubebuilder:validation:Format=date-time
-	//+operator-sdk:csv:customresourcedefinitions:type=status
-	StormTerminationStartTime *metav1.Time `json:"stormTerminationStartTime,omitempty"`
 
 	// LastUpdateTime is the last time the status was updated.
 	//

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -122,8 +122,8 @@ func (in *NodeHealthCheckSpec) DeepCopyInto(out *NodeHealthCheckSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
-	if in.StormTerminationDelay != nil {
-		in, out := &in.StormTerminationDelay, &out.StormTerminationDelay
+	if in.StormCooldownDuration != nil {
+		in, out := &in.StormCooldownDuration, &out.StormCooldownDuration
 		*out = new(v1.Duration)
 		**out = **in
 	}
@@ -196,10 +196,6 @@ func (in *NodeHealthCheckStatus) DeepCopyInto(out *NodeHealthCheckStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
-	}
-	if in.StormTerminationStartTime != nil {
-		in, out := &in.StormTerminationStartTime, &out.StormTerminationStartTime
-		*out = (*in).DeepCopy()
 	}
 	if in.LastUpdateTime != nil {
 		in, out := &in.LastUpdateTime, &out.LastUpdateTime

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -137,16 +137,21 @@ spec:
           to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
-      - description: "StormTerminationDelay introduces a configurable delay after
-          storm recovery exit criteria are satisfied (for example, when the number
-          of healthy nodes rises above the configured minHealthy constraint). While
-          this delay is in effect, NHC remains in storm recovery mode and does not
-          create new remediations. Once the delay elapses, storm recovery mode exits
-          and normal remediation resumes. \n Expects a string of decimal numbers each
-          with optional fraction and a unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\".
-          Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"."
-        displayName: Storm Termination Delay
-        path: stormTerminationDelay
+      - description: "StormCooldownDuration defines the duration of an optional recovery
+          phase after a storm. A \"storm\" happens when the number of (un)healthy
+          nodes exceeds the threshold defined by minHealthy or maxUnhealthy. Sometimes
+          this is triggered by a single root cause. When that cause is fixed, there
+          is a risk to remediate healthy nodes: the async nature of node status updates
+          would result in only some nodes being detected as healthy by NHC in a first
+          round of updates, which results in minHealthy or maxUnhealthy threshold
+          being fulfilled (the storm ends) and triggering unneeded new remediation.
+          The storm recovery phase will prevent creation of new remediation for the
+          given duration by giving NHC some time to get the latest node statuses.
+          \n Expects a string of decimal numbers each with optional fraction and a
+          unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are
+          \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"."
+        displayName: Storm Cooldown Duration
+        path: stormCooldownDuration
       - description: UnhealthyConditions contains a list of the conditions that determine
           whether a node is considered unhealthy.  The conditions are combined in
           a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
@@ -199,11 +204,6 @@ spec:
         path: reason
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase:reason
-      - description: StormTerminationStartTime records when storm recovery mode regained
-          the minHealthy/maxUnhealthy constraint and the storm is about to end (after
-          NodeHealthCheckSpec.StormTerminationDelay has passed).
-        displayName: Storm Termination Start Time
-        path: stormTerminationStartTime
       - description: UnhealthyNodes tracks currently unhealthy nodes and their remediations.
         displayName: Unhealthy Nodes
         path: unhealthyNodes

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -137,7 +137,7 @@ spec:
           to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
-      - description: "StormCooldownDuration defines the duration of an optional recovery
+      - description: "StormCooldownDuration defines the duration of an optional cooldown
           phase after a storm. A \"storm\" happens when the number of (un)healthy
           nodes exceeds the threshold defined by minHealthy or maxUnhealthy. Sometimes
           this is triggered by a single root cause. When that cause is fixed, there
@@ -145,7 +145,7 @@ spec:
           would result in only some nodes being detected as healthy by NHC in a first
           round of updates, which results in minHealthy or maxUnhealthy threshold
           being fulfilled (the storm ends) and triggering unneeded new remediation.
-          The storm recovery phase will prevent creation of new remediation for the
+          The storm cooldown phase will prevent creation of new remediation for the
           given duration by giving NHC some time to get the latest node statuses.
           \n Expects a string of decimal numbers each with optional fraction and a
           unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -275,13 +275,13 @@ spec:
                 x-kubernetes-map-type: atomic
               stormCooldownDuration:
                 description: |-
-                  StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+                  StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
                   A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
                   Sometimes this is triggered by a single root cause.
                   When that cause is fixed, there is a risk to remediate healthy nodes:
                   the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
                   which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
-                  The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+                  The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 
                   Expects a string of decimal numbers each with optional fraction and a unit
                   suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"

--- a/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -273,14 +273,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              stormTerminationDelay:
+              stormCooldownDuration:
                 description: |-
-                  StormTerminationDelay introduces a configurable delay after storm recovery
-                  exit criteria are satisfied (for example, when the number of healthy nodes
-                  rises above the configured minHealthy constraint). While this
-                  delay is in effect, NHC remains in storm recovery mode and does not create
-                  new remediations. Once the delay elapses, storm recovery mode exits and normal
-                  remediation resumes.
+                  StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+                  A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+                  Sometimes this is triggered by a single root cause.
+                  When that cause is fixed, there is a risk to remediate healthy nodes:
+                  the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+                  which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+                  The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 
                   Expects a string of decimal numbers each with optional fraction and a unit
                   suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
@@ -430,12 +431,6 @@ spec:
                 type: string
               reason:
                 description: Reason explains the current phase in more detail.
-                type: string
-              stormTerminationStartTime:
-                description: |-
-                  StormTerminationStartTime records when storm recovery mode regained the minHealthy/maxUnhealthy constraint
-                  and the storm is about to end (after NodeHealthCheckSpec.StormTerminationDelay has passed).
-                format: date-time
                 type: string
               unhealthyNodes:
                 description: UnhealthyNodes tracks currently unhealthy nodes and their

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -273,13 +273,13 @@ spec:
                 x-kubernetes-map-type: atomic
               stormCooldownDuration:
                 description: |-
-                  StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+                  StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
                   A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
                   Sometimes this is triggered by a single root cause.
                   When that cause is fixed, there is a risk to remediate healthy nodes:
                   the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
                   which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
-                  The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+                  The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 
                   Expects a string of decimal numbers each with optional fraction and a unit
                   suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"

--- a/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/config/crd/bases/remediation.medik8s.io_nodehealthchecks.yaml
@@ -271,14 +271,15 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              stormTerminationDelay:
+              stormCooldownDuration:
                 description: |-
-                  StormTerminationDelay introduces a configurable delay after storm recovery
-                  exit criteria are satisfied (for example, when the number of healthy nodes
-                  rises above the configured minHealthy constraint). While this
-                  delay is in effect, NHC remains in storm recovery mode and does not create
-                  new remediations. Once the delay elapses, storm recovery mode exits and normal
-                  remediation resumes.
+                  StormCooldownDuration defines the duration of an optional recovery phase after a storm.
+                  A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+                  Sometimes this is triggered by a single root cause.
+                  When that cause is fixed, there is a risk to remediate healthy nodes:
+                  the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+                  which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+                  The storm recovery phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
 
                   Expects a string of decimal numbers each with optional fraction and a unit
                   suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
@@ -428,12 +429,6 @@ spec:
                 type: string
               reason:
                 description: Reason explains the current phase in more detail.
-                type: string
-              stormTerminationStartTime:
-                description: |-
-                  StormTerminationStartTime records when storm recovery mode regained the minHealthy/maxUnhealthy constraint
-                  and the storm is about to end (after NodeHealthCheckSpec.StormTerminationDelay has passed).
-                format: date-time
                 type: string
               unhealthyNodes:
                 description: UnhealthyNodes tracks currently unhealthy nodes and their

--- a/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -97,16 +97,21 @@ spec:
           to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
-      - description: "StormTerminationDelay introduces a configurable delay after
-          storm recovery exit criteria are satisfied (for example, when the number
-          of healthy nodes rises above the configured minHealthy constraint). While
-          this delay is in effect, NHC remains in storm recovery mode and does not
-          create new remediations. Once the delay elapses, storm recovery mode exits
-          and normal remediation resumes. \n Expects a string of decimal numbers each
-          with optional fraction and a unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\".
-          Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"."
-        displayName: Storm Termination Delay
-        path: stormTerminationDelay
+      - description: "StormCooldownDuration defines the duration of an optional recovery
+          phase after a storm. A \"storm\" happens when the number of (un)healthy
+          nodes exceeds the threshold defined by minHealthy or maxUnhealthy. Sometimes
+          this is triggered by a single root cause. When that cause is fixed, there
+          is a risk to remediate healthy nodes: the async nature of node status updates
+          would result in only some nodes being detected as healthy by NHC in a first
+          round of updates, which results in minHealthy or maxUnhealthy threshold
+          being fulfilled (the storm ends) and triggering unneeded new remediation.
+          The storm recovery phase will prevent creation of new remediation for the
+          given duration by giving NHC some time to get the latest node statuses.
+          \n Expects a string of decimal numbers each with optional fraction and a
+          unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are
+          \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"."
+        displayName: Storm Cooldown Duration
+        path: stormCooldownDuration
       - description: UnhealthyConditions contains a list of the conditions that determine
           whether a node is considered unhealthy.  The conditions are combined in
           a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
@@ -159,11 +164,6 @@ spec:
         path: reason
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase:reason
-      - description: StormTerminationStartTime records when storm recovery mode regained
-          the minHealthy/maxUnhealthy constraint and the storm is about to end (after
-          NodeHealthCheckSpec.StormTerminationDelay has passed).
-        displayName: Storm Termination Start Time
-        path: stormTerminationStartTime
       - description: UnhealthyNodes tracks currently unhealthy nodes and their remediations.
         displayName: Unhealthy Nodes
         path: unhealthyNodes

--- a/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/config/manifests/base/bases/node-healthcheck-operator.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
           to work with an empty selector, which matches all nodes."
         displayName: Selector
         path: selector
-      - description: "StormCooldownDuration defines the duration of an optional recovery
+      - description: "StormCooldownDuration defines the duration of an optional cooldown
           phase after a storm. A \"storm\" happens when the number of (un)healthy
           nodes exceeds the threshold defined by minHealthy or maxUnhealthy. Sometimes
           this is triggered by a single root cause. When that cause is fixed, there
@@ -105,7 +105,7 @@ spec:
           would result in only some nodes being detected as healthy by NHC in a first
           round of updates, which results in minHealthy or maxUnhealthy threshold
           being fulfilled (the storm ends) and triggering unneeded new remediation.
-          The storm recovery phase will prevent creation of new remediation for the
+          The storm cooldown phase will prevent creation of new remediation for the
           given duration by giving NHC some time to get the latest node statuses.
           \n Expects a string of decimal numbers each with optional fraction and a
           unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are

--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Node Health Check CR", func() {
 		var (
 			underTest *v1alpha1.NodeHealthCheck
 			objects   []client.Object
-			//Lease params
+			// Lease params
 			leaseName                             = fmt.Sprintf("%s-%s", "node", unhealthyNodeName)
 			mockRequeueDurationIfLeaseTaken       = time.Second * 2
 			mockDefaultLeaseDuration              = time.Second * 2
@@ -249,7 +249,7 @@ var _ = Describe("Node Health Check CR", func() {
 				}
 			}
 
-			//cleanup lease
+			// Cleanup lease
 			lease := &coordv1.Lease{}
 			err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: leaseNs, Name: leaseName}, lease)
 			if err == nil {
@@ -667,21 +667,21 @@ var _ = Describe("Node Health Check CR", func() {
 					It("node lease is removed", func() {
 						cr := findRemediationCRForNHC(unhealthyNodeName, underTest)
 						Expect(cr).ToNot(BeNil())
-						//Verify lease exist
+						// Verify lease exist
 						lease := &coordv1.Lease{}
 						err := k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 						Expect(err).ToNot(HaveOccurred())
 
-						//Mock node becoming healthy
+						// Mock node becoming healthy
 						mockNodeGettingHealthy(unhealthyNodeName)
 
-						//Remediation should be removed
+						// Remediation should be removed
 						Eventually(func() bool {
 							err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
 							return errors.IsNotFound(err)
 						}, "2s", "100ms").Should(BeTrue(), "remediation CR wasn't removed")
 
-						//Verify NHC removed the lease
+						// Verify NHC removed the lease
 						Eventually(func() bool {
 							err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 							return errors.IsNotFound(err)
@@ -693,7 +693,7 @@ var _ = Describe("Node Health Check CR", func() {
 						cr := findRemediationCRForNHC(unhealthyNodeName, underTest)
 						Expect(cr).ToNot(BeNil())
 
-						//Verify lease exist
+						// Verify lease exist
 						lease := &coordv1.Lease{}
 						err := k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 						Expect(err).ToNot(HaveOccurred())
@@ -703,10 +703,10 @@ var _ = Describe("Node Health Check CR", func() {
 						lease.Spec.HolderIdentity = pointer.String(newLeaseOwner)
 						Expect(k8sClient.Update(context.Background(), lease)).To(Succeed(), "failed to update lease owner")
 
-						//Mock node becoming healthy
+						// Mock node becoming healthy
 						mockNodeGettingHealthy(unhealthyNodeName)
 
-						//Remediation should be removed
+						// Remediation should be removed
 						Eventually(func() bool {
 							err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
 							return errors.IsNotFound(err)
@@ -718,7 +718,7 @@ var _ = Describe("Node Health Check CR", func() {
 							g.Expect(underTest.Status.UnhealthyNodes).To(BeEmpty())
 						}, "2s", "100ms").Should(Succeed(), "status update failed")
 
-						//Verify NHC didn't touch the lease
+						// Verify NHC didn't touch the lease
 						Consistently(func(g Gomega) {
 							g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)).To(Succeed(), "failed to get lease")
 							g.Expect(*lease.Spec.HolderIdentity).To(Equal(newLeaseOwner))
@@ -731,7 +731,7 @@ var _ = Describe("Node Health Check CR", func() {
 					BeforeEach(func() {
 						mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer)
 
-						//Create a mock lease that is already taken
+						// Create a mock lease that is already taken
 						now := metav1.NowMicro()
 						lease := &coordv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: leaseName, Namespace: leaseNs}, Spec: coordv1.LeaseSpec{HolderIdentity: pointer.String("notNHC"), LeaseDurationSeconds: &otherLeaseDurationInSeconds, RenewTime: &now, AcquireTime: &now}}
 						err := k8sClient.Create(context.Background(), lease)
@@ -756,13 +756,13 @@ var _ = Describe("Node Health Check CR", func() {
 								HaveField("Status", metav1.ConditionFalse),
 								HaveField("Reason", v1alpha1.ConditionReasonEnabled),
 							)))
-						//expecting NHC to acquire the lease now and create the CR - checking CR first
+						// Expecting NHC to acquire the lease now and create the CR - checking CR first
 						Eventually(func(g Gomega) {
 							cr = findRemediationCRForNHC(unhealthyNodeName, underTest)
 							g.Expect(cr).ToNot(BeNil())
 						}, mockRequeueDurationIfLeaseTaken*2+time.Millisecond*100, time.Millisecond*100).Should(Succeed())
 
-						//Verifying lease is created
+						// Verifying lease is created
 						lease := &coordv1.Lease{}
 						err := k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 						Expect(err).ToNot(HaveOccurred())
@@ -773,22 +773,22 @@ var _ = Describe("Node Health Check CR", func() {
 						verifyEvent("Warning", utils.EventReasonRemediationSkipped, fmt.Sprintf("Skipped remediation of node: %s, because node lease is already taken", unhealthyNodeName))
 						leaseExpireTime := lease.Spec.AcquireTime.Time.Add(mockRequeueDurationIfLeaseTaken*3 + mockLeaseBuffer)
 						timeLeftForLease := leaseExpireTime.Sub(time.Now())
-						//Wait for lease to be extended
+						// Wait for lease to be extended
 						time.Sleep(timeLeftForLease * 3 / 4)
 						lease = &coordv1.Lease{}
 						err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
-						//Verify NHC extended the lease
+						// Verify NHC extended the lease
 						Expect(err).ToNot(HaveOccurred())
 						Expect(*lease.Spec.AcquireTime).ToNot(Equal(*lease.Spec.RenewTime))
 						Expect(lease.Spec.RenewTime.Sub(lease.Spec.AcquireTime.Time) > 0).To(BeTrue())
 
-						//Wait for lease to expire
+						// Wait for lease to expire
 						time.Sleep(timeLeftForLease/4 + time.Millisecond*100)
 						lease = &coordv1.Lease{}
 						err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
-						//Verify NHC removed the lease
+						// Verify NHC removed the lease
 						Expect(errors.IsNotFound(err)).To(BeTrue())
-						//Verify NHC sets timeout annotation
+						// Verify NHC sets timeout annotation
 						err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(cr), cr)
 						Expect(err).ToNot(HaveOccurred())
 						_, isNhcTimeOutSet := cr.GetAnnotations()[commonannotations.NhcTimedOut]
@@ -838,13 +838,13 @@ var _ = Describe("Node Health Check CR", func() {
 
 			When("node stays unhealthy", func() {
 				BeforeEach(func() {
-					//mocking lease in order to reassure lease extension will trigger a second reconcile (in which the event shouldn't be triggered)
+					// Mocking lease in order to reassure lease extension will trigger a second reconcile (in which the event shouldn't be triggered)
 					mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, mockLeaseBuffer)
 					setupObjects(1, 2, true)
 				})
 				It("Node unhealthy event should occur once", func() {
 					verifyEvent("Normal", utils.EventReasonDetectedUnhealthy, fmt.Sprintf("Node matches unhealthy condition. Node %q, condition type %q, condition status %q", unhealthyNodeName, "Ready", "Unknown"))
-					//After verification event is extracted so this is how we verify it occurred only once
+					// After verification event is extracted so this is how we verify it occurred only once
 					verifyNoEvent("Normal", utils.EventReasonDetectedUnhealthy, fmt.Sprintf("Node matches unhealthy condition. Node %q, condition type %q, condition status %q", unhealthyNodeName, "Ready", "Unknown"))
 
 				})
@@ -984,7 +984,7 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(underTest.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				//Verify lease is created
+				// Verify lease is created
 				lease := &coordv1.Lease{}
 				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 				Expect(err).ToNot(HaveOccurred())
@@ -1000,14 +1000,14 @@ var _ = Describe("Node Health Check CR", func() {
 
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				// get new CR
+				// Get new CR
 				var newCr *unstructured.Unstructured
 				Eventually(func(g Gomega) {
 					newCr = findRemediationCRForNHCSecondRemediation(unhealthyNodeName, underTest)
 					g.Expect(newCr).ToNot(BeNil())
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				// get updated NHC
+				// Get updated NHC
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 					g.Expect(underTest.Status.UnhealthyNodes[0].Remediations[0].Resource.GroupVersionKind()).To(Equal(cr.GroupVersionKind()))
@@ -1028,7 +1028,7 @@ var _ = Describe("Node Health Check CR", func() {
 
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				//Verify lease was extended
+				// Verify lease was extended
 				err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(*lease.Spec.LeaseDurationSeconds).To(Equal(int32(secondRemediationTimeout.Seconds() + mockLeaseBuffer.Seconds())))
@@ -1042,7 +1042,7 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(cr.GetAnnotations()).To(HaveKeyWithValue(Equal("remediation.medik8s.io/nhc-timed-out"), Not(BeNil())))
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				// get updated NHC
+				// Get updated NHC
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 					g.Expect(underTest.Status.UnhealthyNodes[0].Remediations[1].Resource.GroupVersionKind()).To(Equal(newCr.GroupVersionKind()))
@@ -1084,7 +1084,7 @@ var _ = Describe("Node Health Check CR", func() {
 					g.Expect(fourthCR.GetAnnotations()).ToNot(HaveKey(Equal("remediation.medik8s.io/nhc-timed-out")))
 				}, time.Second*10, time.Millisecond*300).Should(Succeed())
 
-				//Verify lease still exist (since long expire time wasn't reached)
+				// Verify lease still exist (since long expire time wasn't reached)
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)).ToNot(HaveOccurred())
 					g.Expect(*lease.Spec.LeaseDurationSeconds).To(Equal(int32(secondRemediationTimeout.Seconds() + mockLeaseBuffer.Seconds())))
@@ -1098,18 +1098,18 @@ var _ = Describe("Node Health Check CR", func() {
 				node.Status.Conditions[0].Status = v1.ConditionTrue
 				Expect(k8sClient.Status().Update(context.Background(), node)).To(Succeed())
 
-				//calculating time left for lease
+				// Calculating time left for lease
 				timeLeftOnLease := time.Duration(*lease.Spec.LeaseDurationSeconds)*time.Second - time.Now().Sub(lease.Spec.RenewTime.Time)
 				// wait a bit
 				time.Sleep(2 * time.Second)
 				timeLeftOnLease = timeLeftOnLease - time.Second*2
-				//Verify lease has time left before it should expire
+				// Verify lease has time left before it should expire
 				Expect(timeLeftOnLease > time.Millisecond*500).To(BeTrue()) // a bit over 1 second at this stage
-				//Verify lease was removed because the CR was deleted (even though there was some time left)
+				// Verify lease was removed because the CR was deleted (even though there was some time left)
 				err = k8sClient.Get(context.Background(), client.ObjectKey{Name: leaseName, Namespace: leaseNs}, lease)
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 
-				// get updated NHC
+				// Get updated NHC
 				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 				Expect(*underTest.Status.HealthyNodes).To(Equal(3))
 				Expect(*underTest.Status.ObservedNodes).To(Equal(3))
@@ -1857,14 +1857,14 @@ var _ = Describe("Node Health Check CR", func() {
 				var currentMachineConfigAnnotationKey = "machineconfiguration.openshift.io/currentConfig"
 				var desiredMachineConfigAnnotationKey = "machineconfiguration.openshift.io/desiredConfig"
 				BeforeEach(func() {
-					//Use a real upgrade checker instead of mock
+					// Use a real upgrade checker instead of mock
 					prevUpgradeChecker := nhcReconciler.ClusterUpgradeStatusChecker
 					nhcReconciler.ClusterUpgradeStatusChecker = ocpUpgradeChecker
 					DeferCleanup(func() {
 						nhcReconciler.ClusterUpgradeStatusChecker = prevUpgradeChecker
 					})
 
-					//Simulate HCP Upgrade on the unhealthy node
+					// Simulate HCP Upgrade on the unhealthy node
 					upgradingNode := objects[0]
 					upgradingNodeAnnotations := map[string]string{}
 					if upgradingNode.GetAnnotations() != nil {
@@ -2000,10 +2000,10 @@ var _ = Describe("Node Health Check CR", func() {
 		})
 
 		Context("Storm Recovery", func() {
-			var stormTerminationDelay = time.Second * 2
+			var stormCooldownDuration = time.Second * 2
 			BeforeEach(func() {
-				underTest = newNodeHealthCheckWithStormRecovery(stormTerminationDelay)
-				setupObjects(3, 4, true) // 2 unhealthy, 5 healthy = 7 total
+				underTest = newNodeHealthCheckWithStormRecovery(stormCooldownDuration, 4)
+				setupObjects(3, 4, true) // 3 unhealthy, 4 healthy = 7 total
 			})
 			When("consecutive storms are triggered", func() {
 				It("they should start and finish according delay and min max criteria", func() {
@@ -2029,43 +2029,56 @@ var _ = Describe("Node Health Check CR", func() {
 
 					// Verify Storm recovery is activated
 					// 7 total, 3 healthy, 4 unhealthy, 3 remediations (additional remediation not created because of min healthy constraint)
-					Eventually(func(g Gomega) {
+					Consistently(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(*underTest.Status.HealthyNodes).To(Equal(3))
 						g.Expect(len(underTest.Status.UnhealthyNodes)).To(Equal(4))
 						g.Expect(getRemediationsCount(underTest)).To(Equal(3))
 						g.Expect(utils.IsConditionTrue(underTest.Status.Conditions, v1alpha1.ConditionTypeStormActive, v1alpha1.ConditionReasonStormThresholdChange)).To(BeTrue())
-					}, "5s", "100ms").Should(Succeed())
+					}, stormCooldownDuration+time.Second, "100ms").Should(Succeed())
 
 					// Phase 3: Recover one node - storm recovery remains active due to 2-second delay
 					By("recovering one node - storm recovery remains active due to 2-second delay")
 					mockNodeGettingHealthy("unhealthy-worker-node-1")
 
-					//wait for node to recover
+					// wait for node to recover
 					Eventually(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(*underTest.Status.HealthyNodes).To(Equal(4))
 					}, "5s", "100ms").Should(Succeed())
 					// 7 total, 4 healthy, 3 unhealthy, 2 remediations (one removed due to healthy node), 1 remediation is pending to be created (not created because of storm)
+
+					var stormTerminationStartTime time.Time
+					// Wait for StormCooldownActive condition to be set
+					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
+						cooldownCondition := meta.FindStatusCondition(underTest.Status.Conditions, v1alpha1.ConditionTypeStormCooldownActive)
+						g.Expect(cooldownCondition).ToNot(BeNil())
+						g.Expect(cooldownCondition.Status).To(Equal(metav1.ConditionTrue))
+						stormTerminationStartTime = cooldownCondition.LastTransitionTime.Time
+					}, "5s", "100ms").Should(Succeed())
+
+					timeUntilStormIsDone := stormTerminationStartTime.Add(stormCooldownDuration).Sub(time.Now())
+
 					Consistently(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(*underTest.Status.HealthyNodes).To(Equal(4))
 						g.Expect(len(underTest.Status.UnhealthyNodes)).To(Equal(3))
 						g.Expect(getRemediationsCount(underTest)).To(Equal(2))
-						g.Expect(utils.IsConditionTrue(underTest.Status.Conditions, v1alpha1.ConditionTypeStormActive, v1alpha1.ConditionReasonStormThresholdChange)).To(BeTrue())
-					}, "2s", "100ms").Should(Succeed())
-					//expected termination time of the first storm
-					firstStormTerminationTime := underTest.Status.StormTerminationStartTime.Time.Add(underTest.Spec.StormTerminationDelay.Duration)
-					// Phase 4: wait for the delay to pass
-					time.Sleep(stormTerminationDelay)
-					//Expect Storm Recovery mode to end
+						g.Expect(utils.IsConditionTrueAnyReason(underTest.Status.Conditions, v1alpha1.ConditionTypeStormCooldownActive)).To(BeTrue())
+					}, timeUntilStormIsDone-time.Millisecond*100, "100ms").Should(Succeed())
+					// Expected termination time of the first storm
+					cooldownCondition := meta.FindStatusCondition(underTest.Status.Conditions, v1alpha1.ConditionTypeStormCooldownActive)
+					firstStormTerminationTime := cooldownCondition.LastTransitionTime.Time.Add(underTest.Spec.StormCooldownDuration.Duration)
+
+					// Expect Storm Recovery mode to end
 					// 7 total, 4 healthy, 3 unhealthy, 3 remediations (pending remediation created when storm is done)
 					Eventually(func(g Gomega) {
 						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(utils.IsConditionSet(underTest.Status.Conditions, v1alpha1.ConditionTypeStormActive, v1alpha1.ConditionReasonStormThresholdChange)).To(BeTrue())
 						g.Expect(utils.IsConditionTrue(underTest.Status.Conditions, v1alpha1.ConditionTypeStormActive, v1alpha1.ConditionReasonStormThresholdChange)).To(BeFalse())
 						g.Expect(getRemediationsCount(underTest)).To(Equal(3))
-					}, "1500ms", "100ms").Should(Succeed())
+					}, "2s", "100ms").Should(Succeed())
 
 					// Phase 5:  Make the fourth node unhealthy - triggers the second storm
 					By("making the 4th node unhealthy - triggers second storm recovery")
@@ -2087,8 +2100,9 @@ var _ = Describe("Node Health Check CR", func() {
 						stormActiveCondition := meta.FindStatusCondition(underTest.Status.Conditions, v1alpha1.ConditionTypeStormActive)
 						// Verifies StormRecoveryStartTime is updated properly when a second storm starts
 						g.Expect(stormActiveCondition.LastTransitionTime.After(firstStormTerminationTime)).To(BeTrue())
-						// Verifies StormTerminationStartTime of the first storm is cleared
-						g.Expect(underTest.Status.StormTerminationStartTime).To(BeNil())
+						// Verifies StormCooldownActive condition of the first storm is cleared
+						cooldownCondition := meta.FindStatusCondition(underTest.Status.Conditions, v1alpha1.ConditionTypeStormCooldownActive)
+						g.Expect(cooldownCondition.Status).To(Equal(metav1.ConditionFalse))
 					}, "5s", "100ms").Should(Succeed())
 				})
 			})
@@ -2797,7 +2811,7 @@ func mockLeaseParams(mockRequeueDurationIfLeaseTaken, mockDefaultLeaseDuration, 
 	orgRequeueIfLeaseTaken := resources.RequeueIfLeaseTaken
 	orgDefaultLeaseDuration := utils.DefaultRemediationDuration
 	orgLeaseBuffer := resources.LeaseBuffer
-	//set up mock values so tests can run in a reasonable time
+	// Set up mock values so tests can run in a reasonable time
 	resources.RequeueIfLeaseTaken = mockRequeueDurationIfLeaseTaken
 	utils.DefaultRemediationDuration = mockDefaultLeaseDuration
 	resources.LeaseBuffer = mockLeaseBuffer
@@ -2881,7 +2895,7 @@ func newBaseCR(nhc *v1alpha1.NodeHealthCheck, templateRef v1.ObjectReference) un
 			return cr
 		}
 	}
-	// can not happen...
+	// Can not happen...
 	return unstructured.Unstructured{}
 }
 
@@ -2891,7 +2905,7 @@ func newBaseCRs(nhc *v1alpha1.NodeHealthCheck) []unstructured.Unstructured {
 	appendCr := func(gvk schema.GroupVersionKind) {
 		cr := unstructured.Unstructured{}
 		kind := gvk.Kind
-		// remove trailing template
+		// Remove trailing template
 		kind = kind[:len(kind)-len("template")]
 		cr.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   gvk.Group,
@@ -2968,12 +2982,11 @@ func setSelectorOnNHC(objects []client.Object, selector metav1.LabelSelector) {
 	}
 }
 
-func newNodeHealthCheckWithStormRecovery(delay time.Duration) *v1alpha1.NodeHealthCheck {
+func newNodeHealthCheckWithStormRecovery(delay time.Duration, minHealthy int32) *v1alpha1.NodeHealthCheck {
 	nhc := newNodeHealthCheck()
-	// 7-node cluster: minHealthy=4, stormRecoveryThreshold=1
-	minHealthy := intstr.FromInt(4)
-	nhc.Spec.MinHealthy = &minHealthy
-	nhc.Spec.StormTerminationDelay = &metav1.Duration{Duration: delay}
+	minHealthyIntStr := intstr.FromInt32(minHealthy)
+	nhc.Spec.MinHealthy = &minHealthyIntStr
+	nhc.Spec.StormCooldownDuration = &metav1.Duration{Duration: delay}
 	return nhc
 }
 
@@ -3107,22 +3120,22 @@ func ptrToIntStr(val string) *intstr.IntOrString {
 }
 
 func mockNodeGettingHealthy(unhealthyNodeName string) {
+	setNodeReadyCondition(unhealthyNodeName, v1.ConditionTrue)
+}
+
+func mockNodeGettingUnhealthy(healthyNodeName string) {
+	setNodeReadyCondition(healthyNodeName, v1.ConditionFalse)
+}
+
+func setNodeReadyCondition(unhealthyNodeName string, conditionStatus v1.ConditionStatus) {
 	node := &v1.Node{}
 	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: unhealthyNodeName}, node)
 	Expect(err).ToNot(HaveOccurred())
 	for i, c := range node.Status.Conditions {
 		if c.Type == v1.NodeReady {
-			node.Status.Conditions[i].Status = v1.ConditionTrue
+			node.Status.Conditions[i].Status = conditionStatus
 		}
 	}
 	err = k8sClient.Status().Update(context.Background(), node)
 	Expect(err).ToNot(HaveOccurred())
-}
-
-func mockNodeGettingUnhealthy(healthyNodeName string) {
-	node := &v1.Node{}
-	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: healthyNodeName}, node)).To(Succeed())
-	node.Status.Conditions[0].Status = v1.ConditionFalse
-	node.Status.Conditions[0].LastTransitionTime = metav1.Now()
-	Expect(k8sClient.Status().Update(context.Background(), node)).To(Succeed())
 }

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -75,17 +75,20 @@ func isHealthy(unhealthyConditions []unhealthyCondition, nodeConditions []corev1
 	return true, nil
 }
 
-// IsConditionTrue return true when the conditions contain a condition of given type and reason with status true
-func IsConditionTrue(conditions []metav1.Condition, conditionType string, reason string) bool {
-	if !IsConditionSet(conditions, conditionType, reason) {
-		return false
-	}
+// IsConditionTrueWithReason return true when the conditions contain a condition of given type and reason with status true
+func IsConditionTrueWithReason(conditions []metav1.Condition, conditionType string, reason string) bool {
 	condition := meta.FindStatusCondition(conditions, conditionType)
-	return condition.Status == metav1.ConditionTrue
+	return condition != nil && condition.Status == metav1.ConditionTrue && condition.Reason == reason
 }
 
-// IsConditionTrueAnyReason returns true when the conditions contain a condition of given type with status true, regardless of reason
-func IsConditionTrueAnyReason(conditions []metav1.Condition, conditionType string) bool {
+// IsConditionFalseWithReason return true when the conditions contain a condition of given type and reason with status false, this isn't the logical opposite of IsConditionTrueWithReason because the condition is expected to be set with a false status.
+func IsConditionFalseWithReason(conditions []metav1.Condition, conditionType string, reason string) bool {
+	condition := meta.FindStatusCondition(conditions, conditionType)
+	return condition != nil && condition.Status == metav1.ConditionFalse && condition.Reason == reason
+}
+
+// IsConditionTrue returns true when the conditions contain a condition of given type with status true, regardless of reason
+func IsConditionTrue(conditions []metav1.Condition, conditionType string) bool {
 	condition := meta.FindStatusCondition(conditions, conditionType)
 	if condition == nil {
 		return false
@@ -93,16 +96,10 @@ func IsConditionTrueAnyReason(conditions []metav1.Condition, conditionType strin
 	return condition.Status == metav1.ConditionTrue
 }
 
-// IsConditionSet return true when the conditions contain a condition of given type and reason
-func IsConditionSet(conditions []metav1.Condition, conditionType string, reason string) bool {
+// IsConditionSet return true when the conditions contain a condition of given type
+func IsConditionSet(conditions []metav1.Condition, conditionType string) bool {
 	condition := meta.FindStatusCondition(conditions, conditionType)
-	if condition == nil {
-		return false
-	}
-	if condition.Reason != reason {
-		return false
-	}
-	return true
+	return condition != nil
 }
 
 func SetMachineCondition(mhc *v1beta1.MachineHealthCheck, condition *v1beta1.Condition) {

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -84,6 +84,15 @@ func IsConditionTrue(conditions []metav1.Condition, conditionType string, reason
 	return condition.Status == metav1.ConditionTrue
 }
 
+// IsConditionTrueAnyReason returns true when the conditions contain a condition of given type with status true, regardless of reason
+func IsConditionTrueAnyReason(conditions []metav1.Condition, conditionType string) bool {
+	condition := meta.FindStatusCondition(conditions, conditionType)
+	if condition == nil {
+		return false
+	}
+	return condition.Status == metav1.ConditionTrue
+}
+
 // IsConditionSet return true when the conditions contain a condition of given type and reason
 func IsConditionSet(conditions []metav1.Condition, conditionType string, reason string) bool {
 	condition := meta.FindStatusCondition(conditions, conditionType)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,11 +272,11 @@ healthyNodes < minHealthy
 → Block new remediations
 ```
 
-**State 3: Regaining Health (Delay)**
+**State 3: Regaining Health (Cooldown)**
 ```
 healthyNodes ≥ minHealthy
 → Start stormCooldownDuration timer
-→ Continue blocking new remediations until delay elapses
+→ Continue blocking new remediations until cooldown elapses
 ```
 
 **State 4: Storm Recovery Exit**

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -27,7 +27,7 @@ when debugging issues, since many steps can potentially fail. See also our
 - Processing stops when minHealthy check fails
 - Unhealthy nodes are remediated:
   - if it's a control plane node, and there are ongoing remediations for other control plane nodes, remediation is skipped for that node
-  - when storm recovery is active (triggered when healthy nodes < minHealthy and stormTerminationDelay is configured), creation of new remediations is blocked
+  - when storm recovery is active (triggered when healthy nodes < minHealthy and stormCooldownDuration is configured), creation of new remediations is blocked
   - if a remediation CR already exists:
     - in all cases, when it is older than 48 hours, a Prometheus metric is increased, which can be used for triggering an alert
     - when using escalating remediations:


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
Some updates according to feedback on #378 
#### Changes made
- removing StormTerminationStartTime in favor of a condition
- some refactoring and improved naming

#### Which issue(s) this PR fixes
[RHWA-16](https://issues.redhat.com//browse/RHWA-16)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cooldown state for storm recovery with a new condition indicating when cooldown is active.

* **Improvements**
  * Renamed configuration field to StormCooldownDuration (replaces StormTerminationDelay) to block new remediations during cooldown.
  * Removed exposed storm start timestamp from status.
  * Enhanced condition utilities for more precise state checks.

* **Documentation**
  * Updated docs and workflow examples to use the new cooldown terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->