### PR TITLE
Fix HealthyDelay test assertions checking stale NHC status

### DIFF
--- a/controllers/nodehealthcheck_controller_test.go
+++ b/controllers/nodehealthcheck_controller_test.go
@@ -1281,11 +1281,9 @@ var _ = Describe("Node Health Check CR", func() {
 						g.Expect(cr).To(BeNil())
 					}, time.Second*3, time.Millisecond*300).Should(Succeed())
 
-					// Get updated NHC
-					Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
-
 					// Check unhealthy was removed
 					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(len(underTest.Status.UnhealthyNodes)).To(BeZero())
 					}, time.Second*3, time.Millisecond*300).Should(Succeed())
 
@@ -1332,11 +1330,9 @@ var _ = Describe("Node Health Check CR", func() {
 						g.Expect(cr).To(BeNil())
 					}, time.Second*3, time.Millisecond*300).Should(Succeed())
 
-					// Get updated NHC
-					Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
-
 					// Check unhealthy was removed
 					Eventually(func(g Gomega) {
+						g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
 						g.Expect(len(underTest.Status.UnhealthyNodes)).To(BeZero())
 					}, time.Second*3, time.Millisecond*300).Should(Succeed())
 


### PR DESCRIPTION
#### Why we need this PR
Some `HealthyDelay` test assertions check a stale NHC status

#### Changes made
Get the NHC CR inside the Eventually block so the object is re-fetched on each polling iteration.


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved node health check cleanup verification tests to ensure resource updates are properly validated during assertion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->