### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
       OLM_VERSION: v0.38.0
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
           echo "Lower skip range bound: ${SKIP_RANGE_LOWER}."
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
@@ -64,37 +64,36 @@ jobs:
       - name: Build and push versioned CSV and images
         run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION SKIP_RANGE_LOWER=$SKIP_RANGE_LOWER make container-build-k8s container-push
 
+      - name: Compress bundle manifests
+        run: tar czf bundle.tar.gz bundle/
+
       - name: Create release with manifests
-        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
-        uses: meeDamian/github-release@2.0
+        uses: softprops/action-gh-release@v2
         with:
-          tag: v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           body: |
             # Node HealthCheck Operator v${{ env.VERSION }}
-            
+
             ## Notable Changes
-            
+
             * TODO
 
             ## Release Artifacts
-            
+
             ### Images
 
             * Operator: quay.io/medik8s/node-healthcheck-operator:v${{ env.VERSION }}
             * Bundle: quay.io/medik8s/node-healthcheck-operator-bundle:v${{ env.VERSION }}
-            
+
             ### Source code and OLM manifests
 
             Please find the source code and the OLM manifests in the `Assets` section below.
-
-          gzip: folders
-          files: >
-            Manifests:bundle/
+          files: bundle.tar.gz
   create_k8s_release_pr:
     if: inputs.operation == 'create_k8s_release_pr'
-    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
+    uses: medik8s/.github/.github/workflows/release_community_bundle.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
@@ -103,7 +102,7 @@ jobs:
       make_targets: "bundle-k8s bundle-update"
   create_okd_release_pr:
     if: inputs.operation == 'create_okd_release_pr'
-    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
+    uses: medik8s/.github/.github/workflows/release_community_bundle.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
#### Why we need this PR

Several GitHub Actions used in CI workflows are outdated or deprecated:
- `actions/checkout` is at v3, current is v6
- `docker/login-action` is at v2, current is v4
- `meeDamian/github-release@2.0` relies on deprecated `set-output` and is no longer maintained
- The shared reusable workflow `release_community_bundle_parametric.yaml` was renamed to `release_community_bundle.yaml` in `medik8s/.github`

#### Changes made

- Bumped `actions/checkout` from v3 to v6 in all workflows (pre-submit, post-submit, release)
- Bumped `docker/login-action` from v2 to v4 in release and post-submit workflows
- Replaced `meeDamian/github-release@2.0` with `softprops/action-gh-release@v2`
- Added explicit `tar czf` step to compress bundle directory (replaces the old action's `gzip: folders` feature)
- Updated reusable workflow references from `release_community_bundle_parametric.yaml` to `release_community_bundle.yaml`

See also: https://github.com/medik8s/node-maintenance-operator/pull/160

#### Which issue(s) this PR fixes

N/A — maintenance/modernization of CI workflows.

#### Test plan

N/A — CI-only changes, verified by the workflows themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)