### PR TITLE
Add optional checkout_ref input to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ name: Release
 on:
   workflow_dispatch:
    inputs:
+     checkout_ref:
+       description: 'Override the ref to checkout (defaults to the triggering ref)'
+       required: false
+       default: ''
      operation:
        description: "The operation to perform."
        required: true
@@ -47,6 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
## Summary

- Adds an optional `checkout_ref` input to the release `workflow_dispatch` trigger
- When provided, overrides the default `github.ref` in the `actions/checkout` step
- Enables triggering release builds from specific branches or tags without relying on the default ref behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to accept an optional Git reference input parameter during manual dispatch, allowing targeted builds from specific branches, tags, or commits instead of the default repository reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->