### PR TITLE
Fix release workflow: forward checkout_ref to community bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,6 +105,7 @@ jobs:
       skip_range_lower: ${{ inputs.skip_range_lower }}
       community: 'K8S'
       make_targets: "bundle-k8s bundle-update"
+      checkout_ref: ${{ inputs.checkout_ref }}
   create_okd_release_pr:
     if: inputs.operation == 'create_okd_release_pr'
     uses: medik8s/.github/.github/workflows/release_community_bundle.yaml@main
@@ -116,3 +117,4 @@ jobs:
       ocp_version: ${{ inputs.ocp_version }}
       community: 'OKD'
       make_targets: "bundle-okd"
+      checkout_ref: ${{ inputs.checkout_ref }}


### PR DESCRIPTION
#### Why we need this PR

The release workflow's community bundle jobs (`create_k8s_release_pr` and `create_okd_release_pr`) do not forward the `checkout_ref` input to the reusable `release_community_bundle.yaml` workflow. This causes the community bundle to check out the wrong ref (main instead of the version tag) when the release script uses `--ref main`.

#### Changes made

- Forward `checkout_ref` input to both `create_k8s_release_pr` and `create_okd_release_pr` jobs

#### Which issue(s) this PR fixes

N/A - bug discovered during release automation work.

#### Test plan

- [x] Verify workflow YAML syntax is valid
- [ ] Trigger a dry-run of the release workflow to confirm inputs are forwarded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow configuration to support improved reference handling during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->