### PR TITLE
docs: update remediation provider responsibility section

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -39,10 +39,30 @@ when debugging issues, since many steps can potentially fail. See also our
 
 ### Remediation providers responsibility
 
-It is up to the remediation provider to delete the remediation CR in case the
-node is deleted, and a new one (with a different name) is reprovisioned.
-In that specific scenario the NHC controller can not detect a successful node
-remediation and delete the remediation CR itself.
+NHC automatically detects when a node has been deleted and cleans up the
+corresponding remediation CR. The remediation provider **should not** delete
+the remediation CR itself.
+
+However, if the remediator's remediation strategy involves **permanent node
+deletion** (e.g. Machine Deletion Remediation), it must signal this to NHC by
+setting a condition on the remediation CR:
+
+- Set a condition of type `PermanentNodeDeletionExpected` with status `True`.
+
+When this condition is present, NHC will wait until the remediator also sets the
+`Succeeded` condition to `True` before deleting the orphaned remediation CR. For
+remediators that do **not** set `PermanentNodeDeletionExpected`, NHC deletes the
+CR immediately after the node disappears.
+
+These condition type constants are available in the
+[medik8s/common](https://github.com/medik8s/common/blob/main/pkg/conditions/conditions.go)
+library:
+
+| Condition Type                  | Purpose                                                              |
+|---------------------------------|----------------------------------------------------------------------|
+| `Processing`                    | Signal that remediation has started / is in progress / has finished  |
+| `Succeeded`                     | Signal whether the remediation was successful or not                 |
+| `PermanentNodeDeletionExpected` | Signal that the unhealthy node will be permanently deleted           |
 
 ### Special cases
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -54,8 +54,10 @@ When this condition is present, NHC will wait until the remediator also sets the
 remediators that do **not** set `PermanentNodeDeletionExpected`, NHC deletes the
 CR immediately after the node disappears.
 
-These condition type constants are available in the
-[medik8s/common](https://github.com/medik8s/common/blob/main/pkg/conditions/conditions.go)
+Remediators can set the following conditions on the remediation CR to
+communicate remediation progress to NHC. The condition type constants are
+available in
+the [medik8s/common](https://github.com/medik8s/common/blob/main/pkg/conditions/conditions.go)
 library:
 
 | Condition Type                  | Purpose                                                              |


### PR DESCRIPTION
#### Why we need this PR

The "Remediation providers responsibility" section in `docs/workflow.md` was outdated. It incorrectly stated that remediation providers should delete the remediation CR themselves when a node is deleted, which caused issues for custom remediator authors (see #266).

#### Changes made

- Updated the "Remediation providers responsibility" section to reflect current NHC behavior:
  - NHC automatically cleans up orphaned remediation CRs when a node is deleted
  - Remediators expecting permanent node deletion should set the `PermanentNodeDeletionExpected` condition
  - NHC waits for `Succeeded` condition before cleanup when `PermanentNodeDeletionExpected` is set
- Added a reference table for condition types from `medik8s/common`

#### Which issue(s) this PR fixes

Fixes #266

#### Test plan

- Documentation-only change, no code changes
- Verified the documented behavior matches the controller logic in `nodehealthcheck_controller.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated remediation workflow to state automatic cleanup of orphaned remediation resources when nodes are detected as deleted.
  * Clarified provider responsibilities and added a required signal for strategies that permanently delete nodes so cleanup can be deferred until completion.
  * Documented new remediation progress conditions (Processing, Succeeded) and referenced their canonical constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->