### PR TITLE
fix(controller): check exclude-from-remediation label value

### DIFF
--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -837,7 +837,7 @@ func (r *NodeHealthCheckReconciler) isNodeRemediationExcluded(node *v1.Node, nhc
 	}
 	if val == "" {
 		msg := fmt.Sprintf("Node %s has exclude-from-remediation label with empty value, label will be ignored. Set value to 'true' to exclude node from remediation", node.GetName())
-		commonevents.WarningEvent(r.Recorder, nhc, utils.EventReasonRemediationSkipped, msg)
+		commonevents.WarningEvent(r.Recorder, nhc, utils.EventReasonInvalidNodeLabel, msg)
 	}
 	return false
 }

--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -367,7 +367,7 @@ func (r *NodeHealthCheckReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			continue
 		}
 
-		if r.isNodeRemediationExcluded(&node) {
+		if r.isNodeRemediationExcluded(&node, nhc) {
 			msg := fmt.Sprintf("Remediation skipped on node %s: node has Exclude from Remediation label", node.GetName())
 			log.Info(msg)
 			commonevents.WarningEvent(r.Recorder, nhc, utils.EventReasonRemediationSkipped, msg)
@@ -823,13 +823,23 @@ func (r *NodeHealthCheckReconciler) alertOldRemediationCR(remediationCR *unstruc
 
 }
 
-func (r *NodeHealthCheckReconciler) isNodeRemediationExcluded(node *v1.Node) bool {
-	if nodeLabels := node.GetLabels(); nodeLabels == nil {
+func (r *NodeHealthCheckReconciler) isNodeRemediationExcluded(node *v1.Node, nhc *remediationv1alpha1.NodeHealthCheck) bool {
+	nodeLabels := node.GetLabels()
+	if nodeLabels == nil {
 		return false
-	} else {
-		_, isNodeExcluded := nodeLabels[commonlabels.ExcludeFromRemediation]
-		return isNodeExcluded
 	}
+	val, exists := nodeLabels[commonlabels.ExcludeFromRemediation]
+	if !exists {
+		return false
+	}
+	if val == "true" {
+		return true
+	}
+	if val == "" {
+		msg := fmt.Sprintf("Node %s has exclude-from-remediation label with empty value, label will be ignored. Set value to 'true' to exclude node from remediation", node.GetName())
+		commonevents.WarningEvent(r.Recorder, nhc, utils.EventReasonRemediationSkipped, msg)
+	}
+	return false
 }
 
 func (r *NodeHealthCheckReconciler) isRemediating(unhealthyNodes []*remediationv1alpha1.UnhealthyNode) bool {

--- a/internal/controller/nodehealthcheck_controller_test.go
+++ b/internal/controller/nodehealthcheck_controller_test.go
@@ -1235,6 +1235,34 @@ var _ = Describe("Node Health Check CR", func() {
 			})
 		})
 
+		Context("with Node having exclude-from-remediation label set to false", func() {
+			BeforeEach(func() {
+				setupObjects(1, 2, true)
+				node := objects[0].(*v1.Node)
+				node.GetLabels()[commonLabels.ExcludeFromRemediation] = "false"
+
+			})
+			It("remediation should be created", func() {
+				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
+			})
+		})
+
+		Context("with Node having exclude-from-remediation label with empty value", func() {
+			BeforeEach(func() {
+				setupObjects(1, 2, true)
+				node := objects[0].(*v1.Node)
+				node.GetLabels()[commonLabels.ExcludeFromRemediation] = ""
+
+			})
+			It("remediation should be created and warning event emitted", func() {
+				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
+				Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
+				// Verify warning event was emitted
+				verifyEvent(v1.EventTypeWarning, utils.EventReasonRemediationSkipped, fmt.Sprintf("Node %s has exclude-from-remediation label with empty value, label will be ignored. Set value to 'true' to exclude node from remediation", unhealthyNodeName))
+			})
+		})
+
 		Context("with Node setup to delay healthy", func() {
 			BeforeEach(func() {
 				setupObjects(1, 2, false)
@@ -2378,6 +2406,52 @@ var _ = Describe("Node Health Check CR", func() {
 				})
 				It("should request reconcile", func() {
 					Expect(labelsNeedReconcile(k8sClient, oldLabels, newLabels, logger)).To(BeTrue())
+				})
+			})
+
+			When("label ExcludeFromRemediation value changes from true to false", func() {
+				BeforeEach(func() {
+					oldLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "true",
+					}
+					newLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "false",
+					}
+				})
+				It("should request reconcile", func() {
+					Expect(labelsNeedReconcile(k8sClient, oldLabels, newLabels, logger)).To(BeTrue())
+				})
+			})
+
+			When("label ExcludeFromRemediation value changes from false to true", func() {
+				BeforeEach(func() {
+					oldLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "false",
+					}
+					newLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "true",
+					}
+				})
+				It("should request reconcile", func() {
+					Expect(labelsNeedReconcile(k8sClient, oldLabels, newLabels, logger)).To(BeTrue())
+				})
+			})
+
+			When("label ExcludeFromRemediation present in both with same value", func() {
+				BeforeEach(func() {
+					oldLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "true",
+					}
+					newLabels = map[string]string{
+						commonLabels.ExcludeFromRemediation: "true",
+					}
+				})
+				It("should not request reconcile for this label alone", func() {
+					// This will be false only if no NHC exists with selectors matching other labels
+					// For this specific test, we're verifying the ExcludeFromRemediation logic doesn't trigger
+					result := labelsNeedReconcile(k8sClient, oldLabels, newLabels, logger)
+					// Since only ExcludeFromRemediation is present and unchanged, should be false
+					Expect(result).To(BeFalse())
 				})
 			})
 

--- a/internal/controller/nodehealthcheck_controller_test.go
+++ b/internal/controller/nodehealthcheck_controller_test.go
@@ -1259,7 +1259,7 @@ var _ = Describe("Node Health Check CR", func() {
 				Expect(underTest.Status.UnhealthyNodes).To(HaveLen(1))
 				Expect(underTest.Status.UnhealthyNodes[0].Remediations).To(HaveLen(1))
 				// Verify warning event was emitted
-				verifyEvent(v1.EventTypeWarning, utils.EventReasonRemediationSkipped, fmt.Sprintf("Node %s has exclude-from-remediation label with empty value, label will be ignored. Set value to 'true' to exclude node from remediation", unhealthyNodeName))
+				verifyEvent(v1.EventTypeWarning, utils.EventReasonInvalidNodeLabel, fmt.Sprintf("Node %s has exclude-from-remediation label with empty value, label will be ignored. Set value to 'true' to exclude node from remediation", unhealthyNodeName))
 			})
 		})
 

--- a/internal/controller/shared.go
+++ b/internal/controller/shared.go
@@ -34,11 +34,11 @@ func nodeUpdateNeedsReconcile(ev event.UpdateEvent, c client.Client, logger logr
 }
 
 func labelsNeedReconcile(c client.Client, oldLabels, newLabels map[string]string, logger logr.Logger) bool {
-	// Check if the ExcludeFromRemediation label was added or removed
-	_, existsInOldLabels := oldLabels[commonLabels.ExcludeFromRemediation]
-	_, existsInNewLabels := newLabels[commonLabels.ExcludeFromRemediation]
+	// Check if the ExcludeFromRemediation label was added, removed, or its value changed
+	oldVal, existsInOldLabels := oldLabels[commonLabels.ExcludeFromRemediation]
+	newVal, existsInNewLabels := newLabels[commonLabels.ExcludeFromRemediation]
 
-	if existsInOldLabels != existsInNewLabels {
+	if existsInOldLabels != existsInNewLabels || oldVal != newVal {
 		return true
 	}
 

--- a/internal/controller/utils/events.go
+++ b/internal/controller/utils/events.go
@@ -5,6 +5,7 @@ const (
 	EventReasonRemediationCreated = "RemediationCreated"
 	EventReasonRemediationSkipped = "RemediationSkipped"
 	EventReasonRemediationRemoved = "RemediationRemoved"
+	EventReasonInvalidNodeLabel   = "InvalidNodeLabel"
 	EventReasonDisabled           = "Disabled"
 	EventReasonEnabled            = "Enabled"
 )


### PR DESCRIPTION
## What
Fixes inconsistent behavior of the `remediation.medik8s.io/exclude-from-remediation` label.

## Why
Currently there is different semantics across medik8s operators:
- **NHC** evaluates the label only for existence, not the value. Setting the label to `"false"` still causes remediation to be skipped.
- **SNR** explicitly checks for value `"true"` to skip remediation.

The vendored constant comment already states the label should have value `"true"`, but NHC code was ignoring the value entirely.

## Changes
1. **`isNodeRemediationExcluded`** - Now checks that label value equals `"true"` (not just existence)
   - Emits warning event when label has empty value
   - Added `nhc` parameter for event recorder
2. **`labelsNeedReconcile`** - Now detects value changes in addition to add/remove
   - Changing label value now triggers reconciliation
3. **Tests** - Added coverage for:
   - Label with value `"false"` → remediation proceeds
   - Label with empty value `""` → remediation proceeds + warning event
   - Label value changes trigger reconcile

## Testing
- All unit tests pass (`make test-no-verify`)
- New tests verify correct behavior for all label value scenarios

Fixes: https://redhat.atlassian.net/browse/RHWA-941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of node remediation exclusion label changes to properly trigger system updates.
  * Fixed remediation exclusion handling with enhanced warning notifications for misconfigured labels.

* **Improvements**
  * Strengthened node remediation exclusion mechanism for more reliable node health check operations and label value change detection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/medik8s/node-healthcheck-operator/pull/407)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->