### PR TITLE
Add bundle-run-update Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,10 @@ bundle-push: ## Push the bundle image
 bundle-run: operator-sdk create-ns ## Run bundle image
 	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle $(BUNDLE_IMG)
 
+.PHONY: bundle-run-update
+bundle-run-update: operator-sdk ## Upgrade bundle image
+	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle-upgrade $(BUNDLE_IMG)
+
 .PHONY: bundle-cleanup
 bundle-cleanup: operator-sdk ## Remove bundle installed via bundle-run
 	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) cleanup $(OPERATOR_NAME) --delete-all


### PR DESCRIPTION
## Why we need this PR

Other medik8s operators (FAR, NMO, SNR, SBR) already have a `bundle-run-update`
Makefile target for OLM-based upgrade testing. NHC is missing this target, which
prevents adding CI upgrade testing (install released version → upgrade → test).

## Changes made

- Add `bundle-run-update` Makefile target wrapping `operator-sdk run bundle-upgrade`
- Follows the same pattern as the existing `bundle-run` target (uses `OPERATOR_NAMESPACE`, depends on `operator-sdk`)

## Which issue(s) this PR fixes

https://redhat.atlassian.net/browse/RHWA-1201

## Test plan

- [ ] `make bundle-run-update` target is recognized by make
- [ ] Target correctly calls `operator-sdk run bundle-upgrade` with the expected namespace and bundle image