### PR TITLE
Add shared dev environment integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testbin/*
 *~
 testdata/.remediators/
 .history/*
+.tools/

--- a/Makefile
+++ b/Makefile
@@ -540,3 +540,22 @@ container-push:  ## Push containers (NOTE: catalog can't be build before bundle 
 
 .PHONY: build-and-run
 build-and-run: container-build-ocp container-push bundle-run
+
+# Shared dev environment
+# Uses a local sibling checkout if available (e.g. ../tools),
+# otherwise downloads the tools repo into .tools/ on first dev-* target use.
+TOOLS_DIR ?= $(shell cd .. && pwd)/tools
+DEV_MK := $(TOOLS_DIR)/dev/dev.mk
+ifeq ($(wildcard $(DEV_MK)),)
+  TOOLS_DIR := $(shell pwd)/.tools
+  DEV_MK := $(TOOLS_DIR)/dev/dev.mk
+endif
+-include $(DEV_MK)
+ifeq ($(wildcard $(DEV_MK)),)
+dev-%:
+	@echo "Downloading medik8s/tools into $(TOOLS_DIR)..."
+	@if [ -d $(TOOLS_DIR) ]; then echo "  Removing stale $(TOOLS_DIR)..."; rm -rf $(TOOLS_DIR); fi
+	@git clone --depth 1 https://github.com/medik8s/tools.git $(TOOLS_DIR)
+	@test -f $(DEV_MK) || { echo "Error: $(DEV_MK) not found after clone."; exit 1; }
+	@$(MAKE) $@
+endif


### PR DESCRIPTION
#### Why we need this PR

Integrates the shared medik8s dev environment from `medik8s/tools`. Adding a small snippet to the Makefile gives all contributors access to `make dev-*` targets for local development and testing.

#### Changes made

- **Makefile**: Added dev environment snippet at the end. Uses a local sibling `../tools` checkout if available, otherwise shallow-clones the tools repo into `.tools/` on first use.
- **.gitignore**: Added `.tools/` to ignore the auto-cloned copy.

#### Available targets after this change

```
make dev-setup              # Create Kind cluster (1 CP + 3 workers)
make dev-deploy             # Build, load image, install CRDs, deploy operator
make dev-describe           # Full summary (nodes, pods, CRs, events)
make dev-simulate-failure   # Stop kubelet on a worker -> triggers remediation
make dev-recover            # Restore all workers
make dev-teardown           # Destroy Kind cluster
make dev-help               # Show all dev targets
```

Also supports external clusters (OCP, etc.) with `SKIP_KIND=true` and ttl.sh ephemeral registry.

#### Which issue(s) this PR fixes

N/A — new functionality.

#### Test plan

- Verified `make dev-setup && make dev-deploy && make dev-describe` works on Kind (podman)
- Verified `SKIP_KIND=true make dev-setup && SKIP_KIND=true make dev-deploy` works on OCP
- Full NHC + SNR remediation flow tested end-to-end