### PR TITLE
Set readOnlyRootFilesystem for console plugin container

### DIFF
--- a/config/optional/console-plugin/deployment.yaml
+++ b/config/optional/console-plugin/deployment.yaml
@@ -28,6 +28,7 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL
@@ -58,6 +59,15 @@ spec:
         - mountPath: /var/serving-cert
           name: nrc-plugin-cert
           readOnly: true
+        - mountPath: /opt/app-root/etc/passwd
+          name: nrc-nss-passwd
+          subPath: passwd
+        - mountPath: /var/log/nginx
+          name: nrc-nginx-log
+        - mountPath: /var/lib/nginx/tmp
+          name: nrc-nginx-tmp
+        - mountPath: /run
+          name: nrc-nginx-run
       securityContext:
         runAsNonRoot: true
       serviceAccountName: console-plugin
@@ -66,3 +76,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: nrc-plugin-cert
+      - name: nrc-nss-passwd
+        emptyDir: {}
+      - name: nrc-nginx-log
+        emptyDir: {}
+      - name: nrc-nginx-tmp
+        emptyDir: {}
+      - name: nrc-nginx-run
+        emptyDir: {}

--- a/internal/controller/nodehealthcheck_controller_test.go
+++ b/internal/controller/nodehealthcheck_controller_test.go
@@ -290,7 +290,10 @@ var _ = Describe("Node Health Check CR", func() {
 					})
 
 					It("should set corresponding condition", func() {
-						expectTemplateNotFound(Default, underTest, "failed to get")
+						Eventually(func(g Gomega) {
+							g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
+							expectTemplateNotFound(g, underTest, "failed to get")
+						}, "5s", "200ms").Should(Succeed(), "expected disabled NHC")
 					})
 				})
 
@@ -304,7 +307,10 @@ var _ = Describe("Node Health Check CR", func() {
 					})
 
 					It("should set corresponding condition", func() {
-						expectTemplateNotFound(Default, underTest, "no namespace is provided")
+						Eventually(func(g Gomega) {
+							g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTest), underTest)).To(Succeed())
+							expectTemplateNotFound(g, underTest, "no namespace is provided")
+						}, "5s", "200ms").Should(Succeed(), "expected disabled NHC")
 					})
 				})
 


### PR DESCRIPTION
## Why we need this PR

The console plugin container lacks `readOnlyRootFilesystem: true`, failing the certsuite immutable root filesystem check. The UBI9 nginx-120 S2I image needs several paths writable at runtime, so emptyDir mounts are added for each.

## Changes made

In `config/optional/console-plugin/deployment.yaml`:

- Set `readOnlyRootFilesystem: true` in the container securityContext
- Added emptyDir volume mounts for writable paths:
  - `/opt/app-root/etc/passwd` (subPath): NSS wrapper writes the running user entry from a template at startup
  - `/var/log/nginx`: S2I run script creates stdout/stderr symlinks here
  - `/var/lib/nginx/tmp`: nginx proxy and temp buffers
  - `/run`: nginx PID file

In `internal/controller/nodehealthcheck_controller_test.go`:

- Fixed flaky "with invalid kind" and "with missing namespace" tests that asserted NHC phase synchronously after a 2-second sleep; replaced with `Eventually` polling (matching the existing pattern for the "template is deleted after NHC creation" test)

## How to test

1. Deploy the NHC operator with the updated console plugin deployment
2. Verify the console plugin pod starts successfully
3. Confirm certsuite immutable root filesystem test passes
4. Verify the console UI is functional

## Prerequisites

Requires the console image from medik8s/node-remediation-console#111 for the nginx logging fix.

## Related

- [RHWA-527](https://redhat.atlassian.net/browse/RHWA-527)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened the Node Remediation console plugin container by using a read-only root filesystem.
  * Added isolated runtime storage for required configuration and nginx paths.

* **Bug Fixes**
  * Improved reconciliation test reliability when validating disabled NodeHealthCheck behavior for invalid or missing remediation templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->