### PR TITLE
Add committed OKD and OCP bundles for hermetic Konflux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ vendor: tidy ## Run go mod vendor
 	go mod vendor
 
 .PHONY: verify
-verify: bundle-reset ## verify there are no un-committed changes
+verify: bundle-reset bundle-okd-reset bundle-ocp-reset ## verify there are no un-committed changes
 	./hack/verify-diff.sh
 
 .PHONY: generate
@@ -355,11 +355,64 @@ bundle-okd: ocp-version-check yq bundle-base ## Generate bundle manifests and me
 	ICON_BASE64="$(shell base64 --wrap=0 ${BLUE_ICON_PATH})" \
 		$(MAKE) bundle-update
 
+.PHONY: bundle-okd-reset
+bundle-okd-reset: manifests kustomize operator-sdk yq ## Generate OKD bundle into bundle-okd/ directory.
+	@# Save the k8s bundle and bundle.Dockerfile, generate OKD bundle, then restore
+	rm -rf bundle-k8s-tmp bundle-okd
+	cp -r bundle bundle-k8s-tmp
+	cp bundle.Dockerfile bundle.Dockerfile.tmp
+	$(OPERATOR_SDK) generate --verbose kustomize manifests --input-dir ./config/manifests/base --output-dir ./config/manifests/base
+	$(KUSTOMIZE) build config/manifests/okd | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(MAKE) add-console-plugin-annotation
+	$(MAKE) add-community-edition-to-display-name
+	@# Strip version-specific data so bundle-okd/ is committable
+	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ${CSV}
+	sed -r -i "/replaces:.*/d" ${CSV}
+	sed -r -i "s|olm.skipRange: .*|olm.skipRange: '>=0.0.1'|;" ${CSV}
+	@# Move to bundle-okd/ and restore k8s bundle
+	mv bundle bundle-okd
+	mv bundle-k8s-tmp bundle
+	mv bundle.Dockerfile.tmp bundle.Dockerfile
+	@echo "bundle-okd/ generated and ready for committing"
+
+.PHONY: bundle-ocp-reset
+bundle-ocp-reset: manifests kustomize operator-sdk yq ## Generate OCP bundle into bundle-ocp/ directory.
+	@# Save the k8s bundle and bundle.Dockerfile, generate OCP bundle, then restore
+	rm -rf bundle-k8s-tmp bundle-ocp
+	cp -r bundle bundle-k8s-tmp
+	cp bundle.Dockerfile bundle.Dockerfile.tmp
+	$(OPERATOR_SDK) generate --verbose kustomize manifests --input-dir ./config/manifests/base --output-dir ./config/manifests/base
+	$(KUSTOMIZE) build config/manifests/ocp | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(MAKE) add-console-plugin-annotation
+	@# Add RELATED_IMAGE_MUST_GATHER env var for disconnected installs
+	$(YQ) -i '( .spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name == "manager") | .env) += [{"name": "RELATED_IMAGE_MUST_GATHER", "value": "$(MUST_GATHER_IMAGE)"}]' ${CSV}
+	@# Add OCP-specific annotations
+	$(YQ) -i '.metadata.annotations."operators.openshift.io/valid-subscription" = "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/disconnected" = "true"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/fips-compliant" = "true"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/proxy-aware" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/tls-profiles" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/token-auth-aws" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/token-auth-azure" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/token-auth-gcp" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/cnf" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/cni" = "false"' ${CSV}
+	$(YQ) -i '.metadata.annotations."features.operators.openshift.io/csi" = "false"' ${CSV}
+	@# Strip version-specific data so bundle-ocp/ is committable
+	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ${CSV}
+	sed -r -i "/replaces:.*/d" ${CSV}
+	sed -r -i "s|olm.skipRange: .*|olm.skipRange: '>=0.0.1'|;" ${CSV}
+	@# Move to bundle-ocp/ and restore k8s bundle
+	mv bundle bundle-ocp
+	mv bundle-k8s-tmp bundle
+	mv bundle.Dockerfile.tmp bundle.Dockerfile
+	@echo "bundle-ocp/ generated and ready for committing"
+
 .PHONY: bundle-ocp
 bundle-ocp: yq bundle-base ## Generate bundle manifests and metadata for OCP, then validate generated files.
 	$(shell rm -r bundle) # OCP bundle should be created from scratch
 	$(KUSTOMIZE) build config/manifests/ocp | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	sed -r -i "s|DOCS_RHWA_VERSION|${DOCS_RHWA_VERSION}|g;" "${CSV}"
+	sed -r -i "s|https://www.medik8s.io/remediation/node-healthcheck-operator/node-healthcheck-operator/|https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/${DOCS_RHWA_VERSION}/html/remediation_fencing_and_maintenance/node-health-check-operator|g;" "${CSV}"
 	# Add env var with must gather image to the NHC container, so its pullspec gets added to the relatedImages section by OSBS
 	#   https://osbs.readthedocs.io/en/osbs_ocp3/users.html?#pinning-pullspecs-for-related-images
 	$(YQ) -i '( .spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name == "manager") | .env) += [{"name": "RELATED_IMAGE_MUST_GATHER", "value": "${MUST_GATHER_IMAGE}"}]' ${CSV}

--- a/bundle-ocp/manifests/manager-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle-ocp/manifests/manager-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - extension-apiserver-authentication
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle-ocp/manifests/manager-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle-ocp/manifests/manager-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/bundle-ocp/manifests/node-healthcheck-ca-bundle_v1_configmap.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-ca-bundle_v1_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-ca-bundle

--- a/bundle-ocp/manifests/node-healthcheck-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: node-healthcheck-tls
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/instance: metrics
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+status:
+  loadBalancer: {}

--- a/bundle-ocp/manifests/node-healthcheck-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle-ocp/manifests/node-healthcheck-node-remediation-console-plugin_v1_service.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-node-remediation-console-plugin_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: nrc-plugin-cert
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: node-remediation-console-plugin
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-node-remediation-console-plugin
+spec:
+  ports:
+  - name: 9443-tcp
+    port: 9443
+    protocol: TCP
+    targetPort: nrc-server
+  selector:
+    app.kubernetes.io/component: node-remediation-console-plugin
+    app.kubernetes.io/name: node-healthcheck-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/bundle-ocp/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -1,0 +1,818 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "remediation.medik8s.io/v1alpha1",
+          "kind": "NodeHealthCheck",
+          "metadata": {
+            "name": "nodehealthcheck-sample"
+          },
+          "spec": {
+            "minHealthy": "51%",
+            "remediationTemplate": {
+              "apiVersion": "self-node-remediation.medik8s.io/v1alpha1",
+              "kind": "SelfNodeRemediationTemplate",
+              "name": "self-node-remediation-automatic-strategy-template",
+              "namespace": "openshift-operators"
+            },
+            "selector": {
+              "matchExpressions": [
+                {
+                  "key": "node-role.kubernetes.io/worker",
+                  "operator": "Exists"
+                }
+              ]
+            },
+            "unhealthyConditions": [
+              {
+                "duration": "300s",
+                "status": "False",
+                "type": "Ready"
+              },
+              {
+                "duration": "300s",
+                "status": "Unknown",
+                "type": "Ready"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    containerImage: quay.io/medik8s/node-healthcheck-operator:v0.0.1
+    createdAt: ""
+    description: Detect failed Nodes and trigger remediation with a remediation operator.
+    olm.skipRange: '>=0.0.1'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/medik8s/node-healthcheck-operator
+    support: Red Hat
+    console.openshift.io/plugins: '["node-remediation-console-plugin"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+  name: node-healthcheck-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: NodeHealthCheck is the Schema for the nodehealthchecks API
+        displayName: Node Health Check
+        kind: NodeHealthCheck
+        name: nodehealthchecks.remediation.medik8s.io
+        resources:
+          - kind: NodeHealthCheck
+            name: nodehealthchecks
+            version: v1alpha1
+        specDescriptors:
+          - description: |-
+              EscalatingRemediations contain a list of ordered remediation templates with a timeout.
+              The remediation templates will be used one after another, until the unhealthy node
+              gets healthy within the timeout of the currently processed remediation. The order of
+              remediation is defined by the "order" field of each "escalatingRemediation".
+
+              Mutually exclusive with RemediationTemplate
+            displayName: Escalating Remediations
+            path: escalatingRemediations
+          - description: |-
+              Order defines the order for this remediation.
+              Remediations with lower order will be used before remediations with higher order.
+              Remediations must not have the same order.
+            displayName: Order
+            path: escalatingRemediations[0].order
+          - description: |-
+              RemediationTemplate is a reference to a remediation template
+              provided by a remediation provider.
+
+              If a node needs remediation the controller will create an object from this template
+              and then it should be picked up by a remediation provider.
+            displayName: Remediation Template
+            path: escalatingRemediations[0].remediationTemplate
+          - description: |-
+              Timeout defines how long NHC will wait for the node getting healthy
+              before the next remediation (if any) will be used. When the last remediation times out,
+              the overall remediation is considered as failed.
+              As a safeguard for preventing parallel remediations, a minimum of 60s is enforced.
+
+              Expects a string of decimal numbers each with optional
+              fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+              Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+            displayName: Timeout
+            path: escalatingRemediations[0].timeout
+          - description: |-
+              HealthyDelay is the time before NHC would allow a node to be healthy again.
+              A negative value means that NHC will never consider the node healthy and a manual intervention is expected
+            displayName: Healthy Delay
+            path: healthyDelay
+          - description: |-
+              Remediation is allowed if no more than "MaxUnhealthy" nodes selected by "selector" are not healthy.
+              Expects either a non-negative integer value or a percentage value.
+              Percentage values must be positive whole numbers and are capped at 100%.
+              0% is valid and will block all remediation.
+              MaxUnhealthy should not be used with remediators that delete nodes (e.g. MachineDeletionRemediation),
+              as this breaks the logic for counting healthy and unhealthy nodes.
+              MinHealthy and MaxUnhealthy are configuring the same aspect,
+              and they cannot be used at the same time.
+            displayName: Max Unhealthy
+            path: maxUnhealthy
+          - description: |-
+              Remediation is allowed if at least "MinHealthy" nodes selected by "selector" are healthy.
+              Expects either a non-negative integer value or a percentage value.
+              Percentage values must be positive whole numbers and are capped at 100%.
+              100% is valid and will block all remediation.
+              MinHealthy and MaxUnhealthy are configuring the same aspect,
+              and they cannot be used at the same time.
+            displayName: Min Healthy
+            path: minHealthy
+          - description: |-
+              PauseRequests will prevent any new remediation to start, while in-flight remediations
+              keep running. Each entry is free form, and ideally represents the requested party reason
+              for this pausing - i.e:
+                  "imaginary-cluster-upgrade-manager-operator"
+            displayName: Pause Requests
+            path: pauseRequests
+          - description: |-
+              RemediationTemplate is a reference to a remediation template
+              provided by an infrastructure provider.
+
+              If a node needs remediation the controller will create an object from this template
+              and then it should be picked up by a remediation provider.
+
+              Mutually exclusive with EscalatingRemediations
+            displayName: Remediation Template
+            path: remediationTemplate
+          - description: |-
+              Label selector to match nodes whose health will be exercised.
+
+              Selecting both control-plane and worker nodes in one NHC CR is
+              highly discouraged and can result in undesired behaviour.
+
+              Note: mandatory now for above reason, but for backwards compatibility existing
+              CRs will continue to work with an empty selector, which matches all nodes.
+            displayName: Selector
+            path: selector
+          - description: |-
+              StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
+              A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+              Sometimes this is triggered by a single root cause.
+              When that cause is fixed, there is a risk to remediate healthy nodes:
+              the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+              which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+              The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+
+              Expects a string of decimal numbers each with optional fraction and a unit
+              suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
+              (or "µs"), "ms", "s", "m", "h".
+            displayName: Storm Cooldown Duration
+            path: stormCooldownDuration
+          - description: |-
+              UnhealthyConditions contains a list of the conditions that determine
+              whether a node is considered unhealthy.  The conditions are combined in a
+              logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+            displayName: Unhealthy Conditions
+            path: unhealthyConditions
+          - description: |-
+              Duration of the condition specified when a node is considered unhealthy.
+
+              Expects a string of decimal numbers each with optional
+              fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+              Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+            displayName: Duration
+            path: unhealthyConditions[0].duration
+          - description: |-
+              The condition status in the node's status to watch for.
+              Typically False, True or Unknown.
+            displayName: Status
+            path: unhealthyConditions[0].status
+          - description: The condition type in the node's status to watch for.
+            displayName: Type
+            path: unhealthyConditions[0].type
+        statusDescriptors:
+          - description: |-
+              Represents the observations of a NodeHealthCheck's current state.
+              Known .status.conditions.type are: "Disabled"
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - description: HealthyNodes specified the number of healthy nodes observed
+            displayName: Healthy Nodes
+            path: healthyNodes
+          - description: |-
+              InFlightRemediations records the timestamp when remediation triggered per node.
+              Deprecated in favour of UnhealthyNodes.
+            displayName: In Flight Remediations
+            path: inFlightRemediations
+          - description: LastUpdateTime is the last time the status was updated.
+            displayName: Last Update Time
+            path: lastUpdateTime
+          - description: ObservedNodes specified the number of nodes observed by using the NHC spec.selector
+            displayName: Observed Nodes
+            path: observedNodes
+          - description: |-
+              Phase represents the current phase of this Config.
+              Known phases are Disabled, Paused, Remediating and Enabled, based on:\n
+              - the status of the Disabled condition\n
+              - the value of PauseRequests\n
+              - the value of InFlightRemediations
+            displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+          - description: Reason explains the current phase in more detail.
+            displayName: Reason
+            path: reason
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase:reason
+          - description: UnhealthyNodes tracks currently unhealthy nodes and their remediations.
+            displayName: Unhealthy Nodes
+            path: unhealthyNodes
+          - description: |-
+              ConditionsHealthyTimestamp is RFC 3339 date and time at which the unhealthy conditions didn't match anymore.
+              The remediation CR will be deleted at that time, but the node will still be tracked as unhealthy until all
+              remediation CRs are actually deleted, when remediators finished cleanup and removed their finalizers.
+            displayName: Conditions Healthy Timestamp
+            path: unhealthyNodes[0].conditionsHealthyTimestamp
+          - description: HealthyDelayed notes whether a node should be considered healthy, but isn't due to NodeHealthCheckSpec.HealthyDelay configuration.
+            displayName: Healthy Delayed
+            path: unhealthyNodes[0].healthyDelayed
+          - description: Name is the name of the unhealthy node
+            displayName: Name
+            path: unhealthyNodes[0].name
+          - description: Remediations tracks the remediations created for this node
+            displayName: Remediations
+            path: unhealthyNodes[0].remediations
+          - description: Resource is the reference to the remediation CR which was created
+            displayName: Resource
+            path: unhealthyNodes[0].remediations[0].resource
+          - description: Started is the creation time of the remediation CR
+            displayName: Started
+            path: unhealthyNodes[0].remediations[0].started
+          - description: TemplateName is required when using several templates of the same kind
+            displayName: Template Name
+            path: unhealthyNodes[0].remediations[0].templateName
+          - description: |-
+              TimedOut is the time when the remediation timed out.
+              Applicable for escalating remediations only.
+            displayName: Timed Out
+            path: unhealthyNodes[0].remediations[0].timedOut
+        version: v1alpha1
+  description: |
+    ### Introduction
+    Hardware is imperfect, and software contains bugs. When node level failures such as kernel hangs or dead NICs
+    occur, the work required from the cluster does not decrease - workloads from affected nodes need to be
+    restarted somewhere.
+
+    However some workloads, such as RWO volumes and StatefulSets, may require at-most-one semantics.
+    Failures affecting these kind of workloads risk data loss and/or corruption if nodes (and the workloads
+    running on them) are assumed to be dead whenever we stop hearing from them. For this reason it is important
+    to know that the node has reached a safe state before initiating recovery of the workload.
+
+    Unfortunately it is not always practical to require admin intervention in order to confirm the node’s true status.
+    In order to automate the recovery of exclusive workloads, we provide operators for failure detection
+    and remediation.
+
+    ### Failure detection: Node Health Check operator
+    The “Node Health Check” (NHC) operator checks each Node’s set of
+    NodeConditions (eg. NotReady) against the criteria and thresholds defined in
+    NodeHealthCheck configuration. If the Node is deemed to be in a failed
+    state, NHC will initiate recovery by using the SIG Cluster API's “External
+    Remediation” API to instantiate the configured remediation template which
+    specifies the mechanism/controller to be used.
+
+    ### Failure handling: External remediators
+    There are multiple remediators for handling node failure that we recommend:
+    - Self Node Remediation (SNR)
+    - Fence Agents Remediation (FAR)
+    - Machine Deletion Remediation (MDR)
+
+    #### Self Node Remediation (SNR)
+    SNR uses watchdog timers and heuristics to ensure nodes enter a safe state
+    (no longer hosting workloads) within a known and finite period of time,
+    before signaling to the system that all Pods on the failed Node are no longer active
+    and can be relocated elsewhere.
+    In the case of transient errors, the watchdog’s actions will also result in
+    the node rebooting and rejoining the cluster - restoring capacity.
+
+    #### Fence Agents Remediation (FAR)
+    FAR uses well-known agents to fence unhealthy nodes, and eventually FAR remediates the nodes.
+    The remediation includes rebooting the unhealthy node using a fence agent,
+    and then evicting workloads from the unhealthy node.
+
+    #### Machine Deletion Remediation (MDR)
+    MDR is limited to OpenShift, and it uses Machine API for reprovisioning unhealthy nodes by deleting their machines.
+  displayName: Node Health Check Operator
+  icon:
+    - base64data: base64EncodedIcon
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - get
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+                - featuregates
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - console.openshift.io
+              resources:
+                - consoleplugins
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machinehealthchecks
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machinehealthchecks/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machines
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - get
+                - list
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+              verbs:
+                - '*'
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: node-healthcheck-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: node-healthcheck-operator
+          name: node-healthcheck-controller-manager
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: controller-manager
+                app.kubernetes.io/name: node-healthcheck-operator
+            strategy:
+              rollingUpdate:
+                maxSurge: 0
+                maxUnavailable: 1
+              type: RollingUpdate
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/component: controller-manager
+                  app.kubernetes.io/name: node-healthcheck-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/infra
+                              operator: Exists
+                        weight: 3
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/master
+                              operator: Exists
+                        weight: 1
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
+                containers:
+                  - args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=0.0.0.0:8443
+                      - --leader-elect
+                      - --enable-http2=false
+                    command:
+                      - /manager
+                    env:
+                      - name: DEPLOYMENT_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: RELATED_IMAGE_MUST_GATHER
+                        value: quay.io/medik8s/must-gather:latest
+                    image: quay.io/medik8s/node-healthcheck-operator:latest
+                    lifecycle:
+                      postStart:
+                        exec:
+                          command:
+                            - /bin/true
+                      preStop:
+                        exec:
+                          command:
+                            - sleep
+                            - "5"
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    startupProbe:
+                      failureThreshold: 12
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      periodSeconds: 5
+                    terminationMessagePolicy: FallbackToLogsOnError
+                    volumeMounts:
+                      - mountPath: /etc/tls/private
+                        name: tls-config
+                        readOnly: true
+                priorityClassName: system-cluster-critical
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: node-healthcheck-controller-manager
+                terminationGracePeriodSeconds: 15
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                  - effect: NoExecute
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                topologySpreadConstraints:
+                  - labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/component: controller-manager
+                        app.kubernetes.io/name: node-healthcheck-operator
+                    maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: DoNotSchedule
+                volumes:
+                  - name: tls-config
+                    secret:
+                      secretName: node-healthcheck-tls
+        - label:
+            app.kubernetes.io/component: node-remediation-console-plugin
+            app.kubernetes.io/name: node-healthcheck-operator
+          name: node-healthcheck-node-remediation-console-plugin
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: node-remediation-console-plugin
+                app.kubernetes.io/name: node-healthcheck-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: node-remediation-console-plugin
+                  app.kubernetes.io/name: node-healthcheck-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/infra
+                              operator: Exists
+                        weight: 3
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/master
+                              operator: Exists
+                        weight: 1
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
+                containers:
+                  - image: quay.io/medik8s/node-remediation-console:latest
+                    lifecycle:
+                      postStart:
+                        exec:
+                          command:
+                            - /bin/true
+                      preStop:
+                        exec:
+                          command:
+                            - sleep
+                            - "5"
+                    livenessProbe:
+                      periodSeconds: 10
+                      tcpSocket:
+                        port: 9443
+                      timeoutSeconds: 3
+                    name: node-remediation-console-plugin
+                    ports:
+                      - containerPort: 9443
+                        name: nrc-server
+                        protocol: TCP
+                    readinessProbe:
+                      periodSeconds: 5
+                      tcpSocket:
+                        port: 9443
+                      timeoutSeconds: 3
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    startupProbe:
+                      failureThreshold: 12
+                      periodSeconds: 5
+                      tcpSocket:
+                        port: 9443
+                    terminationMessagePolicy: FallbackToLogsOnError
+                    volumeMounts:
+                      - mountPath: /var/serving-cert
+                        name: nrc-plugin-cert
+                        readOnly: true
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: node-healthcheck-console-plugin
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                  - effect: NoExecute
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                volumes:
+                  - name: nrc-plugin-cert
+                    secret:
+                      defaultMode: 420
+                      secretName: nrc-plugin-cert
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resourceNames:
+                - no-op-placeholder
+              resources:
+                - configmaps
+              verbs:
+                - get
+          serviceAccountName: node-healthcheck-console-plugin
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: node-healthcheck-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - NHC
+    - Self Node Remediation
+    - SNR
+    - Remediation
+    - Fencing
+    - medik8s
+    - k8s
+  links:
+    - name: Node Healthcheck Operator
+      url: https://www.medik8s.io/remediation/node-healthcheck-operator/node-healthcheck-operator/
+    - name: Source Code
+      url: https://github.com/medik8s/node-healthcheck-operator
+  maintainers:
+    - email: team-dragonfly@redhat.com
+      name: Dragonfly Team
+  maturity: alpha
+  minKubeVersion: 1.20.0
+  provider:
+    name: Red Hat
+    url: https://www.redhat.com
+  version: 0.0.1
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: node-healthcheck-controller-manager
+      failurePolicy: Fail
+      generateName: vnodehealthcheck.kb.io
+      rules:
+        - apiGroups:
+            - remediation.medik8s.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          resources:
+            - nodehealthchecks
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-remediation-medik8s-io-v1alpha1-nodehealthcheck

--- a/bundle-ocp/manifests/node-healthcheck-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle-ocp/manifests/node-healthcheck-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: node-healthcheck-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bundle-ocp/manifests/node-healthcheck-webhook-service_v1_service.yaml
+++ b/bundle-ocp/manifests/node-healthcheck-webhook-service_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+status:
+  loadBalancer: {}

--- a/bundle-ocp/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle-ocp/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -1,0 +1,545 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: nodehealthchecks.remediation.medik8s.io
+spec:
+  group: remediation.medik8s.io
+  names:
+    kind: NodeHealthCheck
+    listKind: NodeHealthCheckList
+    plural: nodehealthchecks
+    shortNames:
+    - nhc
+    singular: nodehealthcheck
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeHealthCheck is the Schema for the nodehealthchecks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeHealthCheckSpec defines the desired state of NodeHealthCheck
+            properties:
+              escalatingRemediations:
+                description: |-
+                  EscalatingRemediations contain a list of ordered remediation templates with a timeout.
+                  The remediation templates will be used one after another, until the unhealthy node
+                  gets healthy within the timeout of the currently processed remediation. The order of
+                  remediation is defined by the "order" field of each "escalatingRemediation".
+
+                  Mutually exclusive with RemediationTemplate
+                items:
+                  description: EscalatingRemediation defines a remediation template
+                    with order and timeout
+                  properties:
+                    order:
+                      description: |-
+                        Order defines the order for this remediation.
+                        Remediations with lower order will be used before remediations with higher order.
+                        Remediations must not have the same order.
+                      type: integer
+                    remediationTemplate:
+                      description: |-
+                        RemediationTemplate is a reference to a remediation template
+                        provided by a remediation provider.
+
+                        If a node needs remediation the controller will create an object from this template
+                        and then it should be picked up by a remediation provider.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    timeout:
+                      description: |-
+                        Timeout defines how long NHC will wait for the node getting healthy
+                        before the next remediation (if any) will be used. When the last remediation times out,
+                        the overall remediation is considered as failed.
+                        As a safeguard for preventing parallel remediations, a minimum of 60s is enforced.
+
+                        Expects a string of decimal numbers each with optional
+                        fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                  required:
+                  - order
+                  - remediationTemplate
+                  - timeout
+                  type: object
+                type: array
+              healthyDelay:
+                description: |-
+                  HealthyDelay is the time before NHC would allow a node to be healthy again.
+                  A negative value means that NHC will never consider the node healthy and a manual intervention is expected
+                pattern: ^-?([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Remediation is allowed if no more than "MaxUnhealthy" nodes selected by "selector" are not healthy.
+                  Expects either a non-negative integer value or a percentage value.
+                  Percentage values must be positive whole numbers and are capped at 100%.
+                  0% is valid and will block all remediation.
+                  MaxUnhealthy should not be used with remediators that delete nodes (e.g. MachineDeletionRemediation),
+                  as this breaks the logic for counting healthy and unhealthy nodes.
+                  MinHealthy and MaxUnhealthy are configuring the same aspect,
+                  and they cannot be used at the same time.
+                pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                x-kubernetes-int-or-string: true
+              minHealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Remediation is allowed if at least "MinHealthy" nodes selected by "selector" are healthy.
+                  Expects either a non-negative integer value or a percentage value.
+                  Percentage values must be positive whole numbers and are capped at 100%.
+                  100% is valid and will block all remediation.
+                  MinHealthy and MaxUnhealthy are configuring the same aspect,
+                  and they cannot be used at the same time.
+                pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                x-kubernetes-int-or-string: true
+              pauseRequests:
+                description: |-
+                  PauseRequests will prevent any new remediation to start, while in-flight remediations
+                  keep running. Each entry is free form, and ideally represents the requested party reason
+                  for this pausing - i.e:
+                      "imaginary-cluster-upgrade-manager-operator"
+                items:
+                  type: string
+                type: array
+              remediationTemplate:
+                description: |-
+                  RemediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  If a node needs remediation the controller will create an object from this template
+                  and then it should be picked up by a remediation provider.
+
+                  Mutually exclusive with EscalatingRemediations
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: |-
+                  Label selector to match nodes whose health will be exercised.
+
+                  Selecting both control-plane and worker nodes in one NHC CR is
+                  highly discouraged and can result in undesired behaviour.
+
+                  Note: mandatory now for above reason, but for backwards compatibility existing
+                  CRs will continue to work with an empty selector, which matches all nodes.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              stormCooldownDuration:
+                description: |-
+                  StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
+                  A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+                  Sometimes this is triggered by a single root cause.
+                  When that cause is fixed, there is a risk to remediate healthy nodes:
+                  the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+                  which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+                  The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+
+                  Expects a string of decimal numbers each with optional fraction and a unit
+                  suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
+                  (or "µs"), "ms", "s", "m", "h".
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              unhealthyConditions:
+                default:
+                - duration: 300s
+                  status: "False"
+                  type: Ready
+                - duration: 300s
+                  status: Unknown
+                  type: Ready
+                description: |-
+                  UnhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a
+                    specified duration. When the named condition has been in the given
+                    status for at least the duration value a node is considered unhealthy.
+                  properties:
+                    duration:
+                      description: |-
+                        Duration of the condition specified when a node is considered unhealthy.
+
+                        Expects a string of decimal numbers each with optional
+                        fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                    status:
+                      description: |-
+                        The condition status in the node's status to watch for.
+                        Typically False, True or Unknown.
+                      minLength: 1
+                      type: string
+                    type:
+                      description: The condition type in the node's status to watch
+                        for.
+                      minLength: 1
+                      type: string
+                  required:
+                  - duration
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - status
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: NodeHealthCheckStatus defines the observed state of NodeHealthCheck
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a NodeHealthCheck's current state.
+                  Known .status.conditions.type are: "Disabled"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              healthyNodes:
+                description: HealthyNodes specified the number of healthy nodes observed
+                type: integer
+              inFlightRemediations:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: |-
+                  InFlightRemediations records the timestamp when remediation triggered per node.
+                  Deprecated in favour of UnhealthyNodes.
+                type: object
+              lastUpdateTime:
+                description: LastUpdateTime is the last time the status was updated.
+                format: date-time
+                type: string
+              observedNodes:
+                description: ObservedNodes specified the number of nodes observed
+                  by using the NHC spec.selector
+                type: integer
+              phase:
+                description: |-
+                  Phase represents the current phase of this Config.
+                  Known phases are Disabled, Paused, Remediating and Enabled, based on:\n
+                  - the status of the Disabled condition\n
+                  - the value of PauseRequests\n
+                  - the value of InFlightRemediations
+                type: string
+              reason:
+                description: Reason explains the current phase in more detail.
+                type: string
+              unhealthyNodes:
+                description: UnhealthyNodes tracks currently unhealthy nodes and their
+                  remediations.
+                items:
+                  description: UnhealthyNode defines an unhealthy node and its remediations
+                  properties:
+                    conditionsHealthyTimestamp:
+                      description: |-
+                        ConditionsHealthyTimestamp is RFC 3339 date and time at which the unhealthy conditions didn't match anymore.
+                        The remediation CR will be deleted at that time, but the node will still be tracked as unhealthy until all
+                        remediation CRs are actually deleted, when remediators finished cleanup and removed their finalizers.
+                      format: date-time
+                      type: string
+                    healthyDelayed:
+                      description: HealthyDelayed notes whether a node should be considered
+                        healthy, but isn't due to NodeHealthCheckSpec.HealthyDelay
+                        configuration.
+                      type: boolean
+                    name:
+                      description: Name is the name of the unhealthy node
+                      type: string
+                    remediations:
+                      description: Remediations tracks the remediations created for
+                        this node
+                      items:
+                        description: Remediation defines a remediation which was created
+                          for a node
+                        properties:
+                          resource:
+                            description: Resource is the reference to the remediation
+                              CR which was created
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          started:
+                            description: Started is the creation time of the remediation
+                              CR
+                            format: date-time
+                            type: string
+                          templateName:
+                            description: TemplateName is required when using several
+                              templates of the same kind
+                            type: string
+                          timedOut:
+                            description: |-
+                              TimedOut is the time when the remediation timed out.
+                              Applicable for escalating remediations only.
+                            format: date-time
+                            type: string
+                        required:
+                        - resource
+                        - started
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle-ocp/metadata/annotations.yaml
+++ b/bundle-ocp/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: node-healthcheck-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle-ocp/tests/scorecard/config.yaml
+++ b/bundle-ocp/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/bundle-okd/manifests/node-healthcheck-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-okd/manifests/node-healthcheck-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+status:
+  loadBalancer: {}

--- a/bundle-okd/manifests/node-healthcheck-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-okd/manifests/node-healthcheck-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle-okd/manifests/node-healthcheck-node-remediation-console-plugin_v1_service.yaml
+++ b/bundle-okd/manifests/node-healthcheck-node-remediation-console-plugin_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: nrc-plugin-cert
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: node-remediation-console-plugin
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-node-remediation-console-plugin
+spec:
+  ports:
+  - name: 9443-tcp
+    port: 9443
+    protocol: TCP
+    targetPort: nrc-server
+  selector:
+    app.kubernetes.io/component: node-remediation-console-plugin
+    app.kubernetes.io/name: node-healthcheck-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/bundle-okd/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle-okd/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -1,0 +1,797 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "remediation.medik8s.io/v1alpha1",
+          "kind": "NodeHealthCheck",
+          "metadata": {
+            "name": "nodehealthcheck-sample"
+          },
+          "spec": {
+            "minHealthy": "51%",
+            "remediationTemplate": {
+              "apiVersion": "self-node-remediation.medik8s.io/v1alpha1",
+              "kind": "SelfNodeRemediationTemplate",
+              "name": "self-node-remediation-automatic-strategy-template",
+              "namespace": "openshift-operators"
+            },
+            "selector": {
+              "matchExpressions": [
+                {
+                  "key": "node-role.kubernetes.io/worker",
+                  "operator": "Exists"
+                }
+              ]
+            },
+            "unhealthyConditions": [
+              {
+                "duration": "300s",
+                "status": "False",
+                "type": "Ready"
+              },
+              {
+                "duration": "300s",
+                "status": "Unknown",
+                "type": "Ready"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    containerImage: quay.io/medik8s/node-healthcheck-operator:v0.0.1
+    createdAt: ""
+    description: Detect failed Nodes and trigger remediation with a remediation operator.
+    olm.skipRange: '>=0.0.1'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/medik8s/node-healthcheck-operator
+    support: Medik8s
+    console.openshift.io/plugins: '["node-remediation-console-plugin"]'
+  name: node-healthcheck-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: NodeHealthCheck is the Schema for the nodehealthchecks API
+        displayName: Node Health Check
+        kind: NodeHealthCheck
+        name: nodehealthchecks.remediation.medik8s.io
+        resources:
+          - kind: NodeHealthCheck
+            name: nodehealthchecks
+            version: v1alpha1
+        specDescriptors:
+          - description: |-
+              EscalatingRemediations contain a list of ordered remediation templates with a timeout.
+              The remediation templates will be used one after another, until the unhealthy node
+              gets healthy within the timeout of the currently processed remediation. The order of
+              remediation is defined by the "order" field of each "escalatingRemediation".
+
+              Mutually exclusive with RemediationTemplate
+            displayName: Escalating Remediations
+            path: escalatingRemediations
+          - description: |-
+              Order defines the order for this remediation.
+              Remediations with lower order will be used before remediations with higher order.
+              Remediations must not have the same order.
+            displayName: Order
+            path: escalatingRemediations[0].order
+          - description: |-
+              RemediationTemplate is a reference to a remediation template
+              provided by a remediation provider.
+
+              If a node needs remediation the controller will create an object from this template
+              and then it should be picked up by a remediation provider.
+            displayName: Remediation Template
+            path: escalatingRemediations[0].remediationTemplate
+          - description: |-
+              Timeout defines how long NHC will wait for the node getting healthy
+              before the next remediation (if any) will be used. When the last remediation times out,
+              the overall remediation is considered as failed.
+              As a safeguard for preventing parallel remediations, a minimum of 60s is enforced.
+
+              Expects a string of decimal numbers each with optional
+              fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+              Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+            displayName: Timeout
+            path: escalatingRemediations[0].timeout
+          - description: |-
+              HealthyDelay is the time before NHC would allow a node to be healthy again.
+              A negative value means that NHC will never consider the node healthy and a manual intervention is expected
+            displayName: Healthy Delay
+            path: healthyDelay
+          - description: |-
+              Remediation is allowed if no more than "MaxUnhealthy" nodes selected by "selector" are not healthy.
+              Expects either a non-negative integer value or a percentage value.
+              Percentage values must be positive whole numbers and are capped at 100%.
+              0% is valid and will block all remediation.
+              MaxUnhealthy should not be used with remediators that delete nodes (e.g. MachineDeletionRemediation),
+              as this breaks the logic for counting healthy and unhealthy nodes.
+              MinHealthy and MaxUnhealthy are configuring the same aspect,
+              and they cannot be used at the same time.
+            displayName: Max Unhealthy
+            path: maxUnhealthy
+          - description: |-
+              Remediation is allowed if at least "MinHealthy" nodes selected by "selector" are healthy.
+              Expects either a non-negative integer value or a percentage value.
+              Percentage values must be positive whole numbers and are capped at 100%.
+              100% is valid and will block all remediation.
+              MinHealthy and MaxUnhealthy are configuring the same aspect,
+              and they cannot be used at the same time.
+            displayName: Min Healthy
+            path: minHealthy
+          - description: |-
+              PauseRequests will prevent any new remediation to start, while in-flight remediations
+              keep running. Each entry is free form, and ideally represents the requested party reason
+              for this pausing - i.e:
+                  "imaginary-cluster-upgrade-manager-operator"
+            displayName: Pause Requests
+            path: pauseRequests
+          - description: |-
+              RemediationTemplate is a reference to a remediation template
+              provided by an infrastructure provider.
+
+              If a node needs remediation the controller will create an object from this template
+              and then it should be picked up by a remediation provider.
+
+              Mutually exclusive with EscalatingRemediations
+            displayName: Remediation Template
+            path: remediationTemplate
+          - description: |-
+              Label selector to match nodes whose health will be exercised.
+
+              Selecting both control-plane and worker nodes in one NHC CR is
+              highly discouraged and can result in undesired behaviour.
+
+              Note: mandatory now for above reason, but for backwards compatibility existing
+              CRs will continue to work with an empty selector, which matches all nodes.
+            displayName: Selector
+            path: selector
+          - description: |-
+              StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
+              A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+              Sometimes this is triggered by a single root cause.
+              When that cause is fixed, there is a risk to remediate healthy nodes:
+              the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+              which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+              The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+
+              Expects a string of decimal numbers each with optional fraction and a unit
+              suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
+              (or "µs"), "ms", "s", "m", "h".
+            displayName: Storm Cooldown Duration
+            path: stormCooldownDuration
+          - description: |-
+              UnhealthyConditions contains a list of the conditions that determine
+              whether a node is considered unhealthy.  The conditions are combined in a
+              logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+            displayName: Unhealthy Conditions
+            path: unhealthyConditions
+          - description: |-
+              Duration of the condition specified when a node is considered unhealthy.
+
+              Expects a string of decimal numbers each with optional
+              fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+              Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+            displayName: Duration
+            path: unhealthyConditions[0].duration
+          - description: |-
+              The condition status in the node's status to watch for.
+              Typically False, True or Unknown.
+            displayName: Status
+            path: unhealthyConditions[0].status
+          - description: The condition type in the node's status to watch for.
+            displayName: Type
+            path: unhealthyConditions[0].type
+        statusDescriptors:
+          - description: |-
+              Represents the observations of a NodeHealthCheck's current state.
+              Known .status.conditions.type are: "Disabled"
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - description: HealthyNodes specified the number of healthy nodes observed
+            displayName: Healthy Nodes
+            path: healthyNodes
+          - description: |-
+              InFlightRemediations records the timestamp when remediation triggered per node.
+              Deprecated in favour of UnhealthyNodes.
+            displayName: In Flight Remediations
+            path: inFlightRemediations
+          - description: LastUpdateTime is the last time the status was updated.
+            displayName: Last Update Time
+            path: lastUpdateTime
+          - description: ObservedNodes specified the number of nodes observed by using the NHC spec.selector
+            displayName: Observed Nodes
+            path: observedNodes
+          - description: |-
+              Phase represents the current phase of this Config.
+              Known phases are Disabled, Paused, Remediating and Enabled, based on:\n
+              - the status of the Disabled condition\n
+              - the value of PauseRequests\n
+              - the value of InFlightRemediations
+            displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+          - description: Reason explains the current phase in more detail.
+            displayName: Reason
+            path: reason
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase:reason
+          - description: UnhealthyNodes tracks currently unhealthy nodes and their remediations.
+            displayName: Unhealthy Nodes
+            path: unhealthyNodes
+          - description: |-
+              ConditionsHealthyTimestamp is RFC 3339 date and time at which the unhealthy conditions didn't match anymore.
+              The remediation CR will be deleted at that time, but the node will still be tracked as unhealthy until all
+              remediation CRs are actually deleted, when remediators finished cleanup and removed their finalizers.
+            displayName: Conditions Healthy Timestamp
+            path: unhealthyNodes[0].conditionsHealthyTimestamp
+          - description: HealthyDelayed notes whether a node should be considered healthy, but isn't due to NodeHealthCheckSpec.HealthyDelay configuration.
+            displayName: Healthy Delayed
+            path: unhealthyNodes[0].healthyDelayed
+          - description: Name is the name of the unhealthy node
+            displayName: Name
+            path: unhealthyNodes[0].name
+          - description: Remediations tracks the remediations created for this node
+            displayName: Remediations
+            path: unhealthyNodes[0].remediations
+          - description: Resource is the reference to the remediation CR which was created
+            displayName: Resource
+            path: unhealthyNodes[0].remediations[0].resource
+          - description: Started is the creation time of the remediation CR
+            displayName: Started
+            path: unhealthyNodes[0].remediations[0].started
+          - description: TemplateName is required when using several templates of the same kind
+            displayName: Template Name
+            path: unhealthyNodes[0].remediations[0].templateName
+          - description: |-
+              TimedOut is the time when the remediation timed out.
+              Applicable for escalating remediations only.
+            displayName: Timed Out
+            path: unhealthyNodes[0].remediations[0].timedOut
+        version: v1alpha1
+  description: |
+    ### Introduction
+    Hardware is imperfect, and software contains bugs. When node level failures such as kernel hangs or dead NICs
+    occur, the work required from the cluster does not decrease - workloads from affected nodes need to be
+    restarted somewhere.
+
+    However some workloads, such as RWO volumes and StatefulSets, may require at-most-one semantics.
+    Failures affecting these kind of workloads risk data loss and/or corruption if nodes (and the workloads
+    running on them) are assumed to be dead whenever we stop hearing from them. For this reason it is important
+    to know that the node has reached a safe state before initiating recovery of the workload.
+
+    Unfortunately it is not always practical to require admin intervention in order to confirm the node’s true status.
+    In order to automate the recovery of exclusive workloads, we provide operators for failure detection
+    and remediation.
+
+    ### Failure detection: Node Health Check operator
+    The “Node Health Check” (NHC) operator checks each Node’s set of
+    NodeConditions (eg. NotReady) against the criteria and thresholds defined in
+    NodeHealthCheck configuration. If the Node is deemed to be in a failed
+    state, NHC will initiate recovery by using the SIG Cluster API's “External
+    Remediation” API to instantiate the configured remediation template which
+    specifies the mechanism/controller to be used.
+
+    ### Failure handling: External remediators
+    There are multiple remediators for handling node failure that we recommend:
+    - Self Node Remediation (SNR)
+    - Fence Agents Remediation (FAR)
+    - Machine Deletion Remediation (MDR)
+
+    #### Self Node Remediation (SNR)
+    SNR uses watchdog timers and heuristics to ensure nodes enter a safe state
+    (no longer hosting workloads) within a known and finite period of time,
+    before signaling to the system that all Pods on the failed Node are no longer active
+    and can be relocated elsewhere.
+    In the case of transient errors, the watchdog’s actions will also result in
+    the node rebooting and rejoining the cluster - restoring capacity.
+
+    #### Fence Agents Remediation (FAR)
+    FAR uses well-known agents to fence unhealthy nodes, and eventually FAR remediates the nodes.
+    The remediation includes rebooting the unhealthy node using a fence agent,
+    and then evicting workloads from the unhealthy node.
+
+    #### Machine Deletion Remediation (MDR)
+    MDR is limited to OpenShift, and it uses Machine API for reprovisioning unhealthy nodes by deleting their machines.
+  displayName: Node Health Check Operator - Community Edition
+  icon:
+    - base64data: base64EncodedIcon
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - get
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+                - featuregates
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - console.openshift.io
+              resources:
+                - consoleplugins
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machinehealthchecks
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machinehealthchecks/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - machine.openshift.io
+              resources:
+                - machines
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - get
+                - list
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+              verbs:
+                - '*'
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - remediation.medik8s.io
+              resources:
+                - nodehealthchecks/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: node-healthcheck-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: node-healthcheck-operator
+          name: node-healthcheck-controller-manager
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: controller-manager
+                app.kubernetes.io/name: node-healthcheck-operator
+            strategy:
+              rollingUpdate:
+                maxSurge: 0
+                maxUnavailable: 1
+              type: RollingUpdate
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/component: controller-manager
+                  app.kubernetes.io/name: node-healthcheck-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/infra
+                              operator: Exists
+                        weight: 3
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/master
+                              operator: Exists
+                        weight: 1
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
+                containers:
+                  - args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=0.0.0.0:8443
+                      - --leader-elect
+                      - --enable-http2=false
+                    command:
+                      - /manager
+                    env:
+                      - name: DEPLOYMENT_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    image: quay.io/medik8s/node-healthcheck-operator:latest
+                    lifecycle:
+                      postStart:
+                        exec:
+                          command:
+                            - /bin/true
+                      preStop:
+                        exec:
+                          command:
+                            - sleep
+                            - "5"
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    startupProbe:
+                      failureThreshold: 12
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      periodSeconds: 5
+                    terminationMessagePolicy: FallbackToLogsOnError
+                priorityClassName: system-cluster-critical
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: node-healthcheck-controller-manager
+                terminationGracePeriodSeconds: 15
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                  - effect: NoExecute
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                topologySpreadConstraints:
+                  - labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/component: controller-manager
+                        app.kubernetes.io/name: node-healthcheck-operator
+                    maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: DoNotSchedule
+        - label:
+            app.kubernetes.io/component: node-remediation-console-plugin
+            app.kubernetes.io/name: node-healthcheck-operator
+          name: node-healthcheck-node-remediation-console-plugin
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: node-remediation-console-plugin
+                app.kubernetes.io/name: node-healthcheck-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: node-remediation-console-plugin
+                  app.kubernetes.io/name: node-healthcheck-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/infra
+                              operator: Exists
+                        weight: 3
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/master
+                              operator: Exists
+                        weight: 1
+                      - preference:
+                          matchExpressions:
+                            - key: node-role.kubernetes.io/control-plane
+                              operator: Exists
+                        weight: 1
+                containers:
+                  - image: quay.io/medik8s/node-remediation-console:latest
+                    lifecycle:
+                      postStart:
+                        exec:
+                          command:
+                            - /bin/true
+                      preStop:
+                        exec:
+                          command:
+                            - sleep
+                            - "5"
+                    livenessProbe:
+                      periodSeconds: 10
+                      tcpSocket:
+                        port: 9443
+                      timeoutSeconds: 3
+                    name: node-remediation-console-plugin
+                    ports:
+                      - containerPort: 9443
+                        name: nrc-server
+                        protocol: TCP
+                    readinessProbe:
+                      periodSeconds: 5
+                      tcpSocket:
+                        port: 9443
+                      timeoutSeconds: 3
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    startupProbe:
+                      failureThreshold: 12
+                      periodSeconds: 5
+                      tcpSocket:
+                        port: 9443
+                    terminationMessagePolicy: FallbackToLogsOnError
+                    volumeMounts:
+                      - mountPath: /var/serving-cert
+                        name: nrc-plugin-cert
+                        readOnly: true
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: node-healthcheck-console-plugin
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                  - effect: NoExecute
+                    key: node-role.kubernetes.io/infra
+                    operator: Exists
+                volumes:
+                  - name: nrc-plugin-cert
+                    secret:
+                      defaultMode: 420
+                      secretName: nrc-plugin-cert
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resourceNames:
+                - no-op-placeholder
+              resources:
+                - configmaps
+              verbs:
+                - get
+          serviceAccountName: node-healthcheck-console-plugin
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: node-healthcheck-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - NHC
+    - Self Node Remediation
+    - SNR
+    - Remediation
+    - Fencing
+    - medik8s
+    - k8s
+  links:
+    - name: Node Healthcheck Operator
+      url: https://medik8s.io
+    - name: Source Code
+      url: https://github.com/medik8s/node-healthcheck-operator
+  maintainers:
+    - email: medik8s@googlegroups.com
+      name: Medik8s Team
+  maturity: alpha
+  minKubeVersion: 1.20.0
+  provider:
+    name: Medik8s
+    url: https://github.com/medik8s
+  version: 0.0.1
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: node-healthcheck-controller-manager
+      failurePolicy: Fail
+      generateName: vnodehealthcheck.kb.io
+      rules:
+        - apiGroups:
+            - remediation.medik8s.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          resources:
+            - nodehealthchecks
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-remediation-medik8s-io-v1alpha1-nodehealthcheck

--- a/bundle-okd/manifests/node-healthcheck-webhook-service_v1_service.yaml
+++ b/bundle-okd/manifests/node-healthcheck-webhook-service_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: node-healthcheck-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/name: node-healthcheck-operator
+status:
+  loadBalancer: {}

--- a/bundle-okd/manifests/remediation.medik8s.io_nodehealthchecks.yaml
+++ b/bundle-okd/manifests/remediation.medik8s.io_nodehealthchecks.yaml
@@ -1,0 +1,545 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: node-healthcheck-operator
+  name: nodehealthchecks.remediation.medik8s.io
+spec:
+  group: remediation.medik8s.io
+  names:
+    kind: NodeHealthCheck
+    listKind: NodeHealthCheckList
+    plural: nodehealthchecks
+    shortNames:
+    - nhc
+    singular: nodehealthcheck
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeHealthCheck is the Schema for the nodehealthchecks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeHealthCheckSpec defines the desired state of NodeHealthCheck
+            properties:
+              escalatingRemediations:
+                description: |-
+                  EscalatingRemediations contain a list of ordered remediation templates with a timeout.
+                  The remediation templates will be used one after another, until the unhealthy node
+                  gets healthy within the timeout of the currently processed remediation. The order of
+                  remediation is defined by the "order" field of each "escalatingRemediation".
+
+                  Mutually exclusive with RemediationTemplate
+                items:
+                  description: EscalatingRemediation defines a remediation template
+                    with order and timeout
+                  properties:
+                    order:
+                      description: |-
+                        Order defines the order for this remediation.
+                        Remediations with lower order will be used before remediations with higher order.
+                        Remediations must not have the same order.
+                      type: integer
+                    remediationTemplate:
+                      description: |-
+                        RemediationTemplate is a reference to a remediation template
+                        provided by a remediation provider.
+
+                        If a node needs remediation the controller will create an object from this template
+                        and then it should be picked up by a remediation provider.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    timeout:
+                      description: |-
+                        Timeout defines how long NHC will wait for the node getting healthy
+                        before the next remediation (if any) will be used. When the last remediation times out,
+                        the overall remediation is considered as failed.
+                        As a safeguard for preventing parallel remediations, a minimum of 60s is enforced.
+
+                        Expects a string of decimal numbers each with optional
+                        fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                  required:
+                  - order
+                  - remediationTemplate
+                  - timeout
+                  type: object
+                type: array
+              healthyDelay:
+                description: |-
+                  HealthyDelay is the time before NHC would allow a node to be healthy again.
+                  A negative value means that NHC will never consider the node healthy and a manual intervention is expected
+                pattern: ^-?([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Remediation is allowed if no more than "MaxUnhealthy" nodes selected by "selector" are not healthy.
+                  Expects either a non-negative integer value or a percentage value.
+                  Percentage values must be positive whole numbers and are capped at 100%.
+                  0% is valid and will block all remediation.
+                  MaxUnhealthy should not be used with remediators that delete nodes (e.g. MachineDeletionRemediation),
+                  as this breaks the logic for counting healthy and unhealthy nodes.
+                  MinHealthy and MaxUnhealthy are configuring the same aspect,
+                  and they cannot be used at the same time.
+                pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                x-kubernetes-int-or-string: true
+              minHealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  Remediation is allowed if at least "MinHealthy" nodes selected by "selector" are healthy.
+                  Expects either a non-negative integer value or a percentage value.
+                  Percentage values must be positive whole numbers and are capped at 100%.
+                  100% is valid and will block all remediation.
+                  MinHealthy and MaxUnhealthy are configuring the same aspect,
+                  and they cannot be used at the same time.
+                pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                x-kubernetes-int-or-string: true
+              pauseRequests:
+                description: |-
+                  PauseRequests will prevent any new remediation to start, while in-flight remediations
+                  keep running. Each entry is free form, and ideally represents the requested party reason
+                  for this pausing - i.e:
+                      "imaginary-cluster-upgrade-manager-operator"
+                items:
+                  type: string
+                type: array
+              remediationTemplate:
+                description: |-
+                  RemediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  If a node needs remediation the controller will create an object from this template
+                  and then it should be picked up by a remediation provider.
+
+                  Mutually exclusive with EscalatingRemediations
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: |-
+                  Label selector to match nodes whose health will be exercised.
+
+                  Selecting both control-plane and worker nodes in one NHC CR is
+                  highly discouraged and can result in undesired behaviour.
+
+                  Note: mandatory now for above reason, but for backwards compatibility existing
+                  CRs will continue to work with an empty selector, which matches all nodes.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              stormCooldownDuration:
+                description: |-
+                  StormCooldownDuration defines the duration of an optional cooldown phase after a storm.
+                  A "storm" happens when the number of (un)healthy nodes exceeds the threshold defined by minHealthy or maxUnhealthy.
+                  Sometimes this is triggered by a single root cause.
+                  When that cause is fixed, there is a risk to remediate healthy nodes:
+                  the async nature of node status updates would result in only some nodes being detected as healthy by NHC in a first round of updates,
+                  which results in minHealthy or maxUnhealthy threshold being fulfilled (the storm ends) and triggering unneeded new remediation.
+                  The storm cooldown phase will prevent creation of new remediation for the given duration by giving NHC some time to get the latest node statuses.
+
+                  Expects a string of decimal numbers each with optional fraction and a unit
+                  suffix, e.g. "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
+                  (or "µs"), "ms", "s", "m", "h".
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              unhealthyConditions:
+                default:
+                - duration: 300s
+                  status: "False"
+                  type: Ready
+                - duration: 300s
+                  status: Unknown
+                  type: Ready
+                description: |-
+                  UnhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a
+                    specified duration. When the named condition has been in the given
+                    status for at least the duration value a node is considered unhealthy.
+                  properties:
+                    duration:
+                      description: |-
+                        Duration of the condition specified when a node is considered unhealthy.
+
+                        Expects a string of decimal numbers each with optional
+                        fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                      type: string
+                    status:
+                      description: |-
+                        The condition status in the node's status to watch for.
+                        Typically False, True or Unknown.
+                      minLength: 1
+                      type: string
+                    type:
+                      description: The condition type in the node's status to watch
+                        for.
+                      minLength: 1
+                      type: string
+                  required:
+                  - duration
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - status
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: NodeHealthCheckStatus defines the observed state of NodeHealthCheck
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a NodeHealthCheck's current state.
+                  Known .status.conditions.type are: "Disabled"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              healthyNodes:
+                description: HealthyNodes specified the number of healthy nodes observed
+                type: integer
+              inFlightRemediations:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: |-
+                  InFlightRemediations records the timestamp when remediation triggered per node.
+                  Deprecated in favour of UnhealthyNodes.
+                type: object
+              lastUpdateTime:
+                description: LastUpdateTime is the last time the status was updated.
+                format: date-time
+                type: string
+              observedNodes:
+                description: ObservedNodes specified the number of nodes observed
+                  by using the NHC spec.selector
+                type: integer
+              phase:
+                description: |-
+                  Phase represents the current phase of this Config.
+                  Known phases are Disabled, Paused, Remediating and Enabled, based on:\n
+                  - the status of the Disabled condition\n
+                  - the value of PauseRequests\n
+                  - the value of InFlightRemediations
+                type: string
+              reason:
+                description: Reason explains the current phase in more detail.
+                type: string
+              unhealthyNodes:
+                description: UnhealthyNodes tracks currently unhealthy nodes and their
+                  remediations.
+                items:
+                  description: UnhealthyNode defines an unhealthy node and its remediations
+                  properties:
+                    conditionsHealthyTimestamp:
+                      description: |-
+                        ConditionsHealthyTimestamp is RFC 3339 date and time at which the unhealthy conditions didn't match anymore.
+                        The remediation CR will be deleted at that time, but the node will still be tracked as unhealthy until all
+                        remediation CRs are actually deleted, when remediators finished cleanup and removed their finalizers.
+                      format: date-time
+                      type: string
+                    healthyDelayed:
+                      description: HealthyDelayed notes whether a node should be considered
+                        healthy, but isn't due to NodeHealthCheckSpec.HealthyDelay
+                        configuration.
+                      type: boolean
+                    name:
+                      description: Name is the name of the unhealthy node
+                      type: string
+                    remediations:
+                      description: Remediations tracks the remediations created for
+                        this node
+                      items:
+                        description: Remediation defines a remediation which was created
+                          for a node
+                        properties:
+                          resource:
+                            description: Resource is the reference to the remediation
+                              CR which was created
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          started:
+                            description: Started is the creation time of the remediation
+                              CR
+                            format: date-time
+                            type: string
+                          templateName:
+                            description: TemplateName is required when using several
+                              templates of the same kind
+                            type: string
+                          timedOut:
+                            description: |-
+                              TimedOut is the time when the remediation timed out.
+                              Applicable for escalating remediations only.
+                            format: date-time
+                            type: string
+                        required:
+                        - resource
+                        - started
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle-okd/metadata/annotations.yaml
+++ b/bundle-okd/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: node-healthcheck-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle-okd/tests/scorecard/config.yaml
+++ b/bundle-okd/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.31.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/manifests/ocp/clusterserviceversion_patch.yaml
+++ b/config/manifests/ocp/clusterserviceversion_patch.yaml
@@ -14,6 +14,6 @@ spec:
     url: https://www.redhat.com
   links:
     - name: Node Healthcheck Operator
-      url: https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/DOCS_RHWA_VERSION/html/remediation_fencing_and_maintenance/node-health-check-operator
+      url: https://www.medik8s.io/remediation/node-healthcheck-operator/node-healthcheck-operator/
     - name: Source Code
       url: https://github.com/medik8s/node-healthcheck-operator


### PR DESCRIPTION
## Summary

The `bundle.ci.Dockerfile` installs Go and runs `make bundle-ocp-ci` inside the image build, which requires network access. This is incompatible with Konflux hermetic (no-network) builds.

Fix this by committing pre-built `bundle-ocp/` and `bundle-okd/` directories that downstream Containerfiles can `COPY` directly without needing any build tools or network access.

Fixes: [RHWA-294](https://redhat.atlassian.net/browse/RHWA-294)

## Changes

- Add `bundle-ocp/` with all OCP-specific resources (TLS, prometheus, RBAC, console plugin, OCP annotations, branding)
- Add `bundle-okd/` with OKD/community-specific resources
- Add `bundle-ocp-reset` and `bundle-okd-reset` Makefile targets to regenerate committed bundles
- `make verify` validates both bundles are up to date, preventing drift
- Use real upstream `medik8s.io` docs URL in `bundle-ocp/` instead of a raw `DOCS_RHWA_VERSION` placeholder, so the committed bundle is valid standalone. The `bundle-ocp` Makefile target (used by non-hermetic CI) substitutes the downstream RHWA docs URL at generation time.

## Downstream impact

The midstream `update_bundle.sh` and `test_update_bundle.sh` scripts need to be updated to match the docs URL change (replace the real URL instead of the `DOCS_RHWA_VERSION` placeholder). A companion midstream MR is prepared on branch `fix-bundle-update-robustness` with these changes plus additional robustness improvements (explicit image regex, relatedImages count validation, test assertions).

## How it was tested

- `make bundle-reset` — k8s bundle generates and validates successfully
- `make bundle-okd-reset` — OKD bundle generates cleanly
- `make bundle-ocp-reset` — OCP bundle generates cleanly
- `make verify` — confirms all three committed bundles have no drift
- Downstream `update_bundle.sh` tested against the new `bundle-ocp/` CSV — produces identical output to the previous approach (verified via diff, zero changes apart from the now-correctly-resolved docs URL)
- Downstream test script (`test_update_bundle.sh`) passes all 9 assertions plus built-in validation

## Test plan

- [ ] Verify `make verify` passes with no uncommitted changes
- [ ] Verify `make bundle-ocp-reset && make verify` round-trips cleanly
- [ ] Verify downstream bundle build produces correct CSV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift and OKD deployment bundles for the Node Health Check Operator.
  * Added NodeHealthCheck custom resources, validation, monitoring access, webhooks, metrics services, and console plugin services.
  * Added platform-specific permissions, certificates, metadata, and scorecard validation configurations.
* **Bug Fixes**
  * Improved bundle verification and normalization for OpenShift and OKD variants.
  * Updated documentation links in the OpenShift bundle.
  * Corrected the provider documentation link to the Medik8s remediation project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->