### PR TITLE
Add automated Go version update workflow

### DIFF
--- a/.github/workflows/go-update.yaml
+++ b/.github/workflows/go-update.yaml
@@ -1,0 +1,18 @@
+name: Go Version Update
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run — show changes without creating a PR"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  update:
+    uses: medik8s/.github/.github/workflows/update-go-version.yaml@main
+    with:
+      version-schema: ocp-4.22
+      dry-run: ${{ inputs.dry-run || false }}


### PR DESCRIPTION
## Summary

Add a thin caller workflow for the centralized Go version update automation.

This workflow calls the reusable `update-go-version` workflow from
`medik8s/.github`, which:
- Updates `go.mod` to the target Go minor version (drops `.0` suffix)
- Removes the `toolchain` directive (patch versions handled by CI builder)
- Runs `go mod tidy` + `go mod vendor`
- Updates `.ci-operator.yaml` builder image tag
- Verifies build passes
- Creates a PR with all changes

Runs weekly (Monday 8:00 UTC) and on manual dispatch. Supports dry-run mode.

Depends-On: https://github.com/medik8s/.github/pull/21

## Test plan

- [ ] Merge the .github PR first
- [ ] Run this workflow via `workflow_dispatch` with dry-run enabled
- [ ] Verify the generated PR has correct changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated weekly process to check for Go version updates.
  * Added an option to manually run the update process in dry-run mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->