### PR TITLE
Add test coverage for programmatic ServiceMonitor creation

### DIFF
--- a/e2e/servicemonitor_e2e_test.go
+++ b/e2e/servicemonitor_e2e_test.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/medik8s/node-healthcheck-operator/internal/controller/servicemonitor"
 )
 
 var serviceMonitorGVR = schema.GroupVersionResource{
@@ -21,11 +23,6 @@ var serviceMonitorGVR = schema.GroupVersionResource{
 
 var _ = Describe("ServiceMonitor", Ordered, labelOcpOnly, func() {
 
-	const (
-		serviceMonitorName = "node-healthcheck-controller-manager-metrics-monitor"
-		serviceName        = "node-healthcheck-controller-manager-metrics-service"
-	)
-
 	var sm *unstructured.Unstructured
 
 	BeforeAll(func() {
@@ -34,7 +31,7 @@ var _ = Describe("ServiceMonitor", Ordered, labelOcpOnly, func() {
 			var err error
 			sm, err = dynamicClient.Resource(serviceMonitorGVR).Namespace(operatorNsName).Get(
 				context.Background(),
-				serviceMonitorName,
+				servicemonitor.ServiceMonitorName,
 				metav1.GetOptions{},
 			)
 			g.Expect(err).ToNot(HaveOccurred(), "ServiceMonitor should exist in operator namespace")
@@ -55,15 +52,35 @@ var _ = Describe("ServiceMonitor", Ordered, labelOcpOnly, func() {
 		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
 		Expect(ok).To(BeTrue(), "endpoint should have tlsConfig")
 
-		expectedServerName := fmt.Sprintf("%s.%s.svc", serviceName, operatorNsName)
+		expectedServerName := fmt.Sprintf("%s.%s.svc", servicemonitor.ServiceName, operatorNsName)
 		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName),
 			"serverName must be dynamically constructed from the operator namespace, not hardcoded")
+	})
+
+	It("should have selector matchLabels matching the metrics Service", func() {
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		selector, ok := spec["selector"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "spec should have selector")
+
+		matchLabels, ok := selector["matchLabels"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "selector should have matchLabels")
+
+		svc, err := clientSet.CoreV1().Services(operatorNsName).Get(
+			context.Background(), servicemonitor.ServiceName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred(), "metrics Service should exist")
+
+		for key, val := range matchLabels {
+			Expect(svc.Labels).To(HaveKeyWithValue(key, val),
+				"Service label %s should match ServiceMonitor selector", key)
+		}
 	})
 
 	It("should have cluster-monitoring label on operator namespace", func() {
 		ns, err := clientSet.CoreV1().Namespaces().Get(context.Background(), operatorNsName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ns.Labels).To(HaveKeyWithValue("openshift.io/cluster-monitoring", "true"),
+		Expect(ns.Labels).To(HaveKeyWithValue(servicemonitor.ClusterMonitoringLabel, servicemonitor.ClusterMonitoringValue),
 			"operator namespace must be labeled for Prometheus discovery")
 	})
 
@@ -86,16 +103,16 @@ var _ = Describe("ServiceMonitor", Ordered, labelOcpOnly, func() {
 		configMap, ok := ca["configMap"].(map[string]interface{})
 		Expect(ok).To(BeTrue(), "ca should have configMap")
 
-		Expect(configMap["name"]).To(Equal("node-healthcheck-ca-bundle"),
+		Expect(configMap["name"]).To(Equal(servicemonitor.CAConfigMapName),
 			"CA ConfigMap name should reference the service-ca injected bundle")
-		Expect(configMap["key"]).To(Equal("service-ca.crt"))
+		Expect(configMap["key"]).To(Equal(servicemonitor.CAConfigMapKey))
 	})
 
 	It("should use the tls-client-certificate-auth scrape class", func() {
 		spec, ok := sm.Object["spec"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
 
-		Expect(spec["scrapeClass"]).To(Equal("tls-client-certificate-auth"),
+		Expect(spec["scrapeClass"]).To(Equal(servicemonitor.ScrapeClass),
 			"scrapeClass must be set for Platform Prometheus mTLS")
 	})
 })

--- a/e2e/servicemonitor_e2e_test.go
+++ b/e2e/servicemonitor_e2e_test.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var serviceMonitorGVR = schema.GroupVersionResource{
+	Group:    "monitoring.coreos.com",
+	Version:  "v1",
+	Resource: "servicemonitors",
+}
+
+var _ = Describe("ServiceMonitor", Ordered, labelOcpOnly, func() {
+
+	const (
+		serviceMonitorName = "node-healthcheck-controller-manager-metrics-monitor"
+		serviceName        = "node-healthcheck-controller-manager-metrics-service"
+	)
+
+	var sm *unstructured.Unstructured
+
+	BeforeAll(func() {
+		// Wait for ServiceMonitor to be created by the operator at startup
+		Eventually(func(g Gomega) {
+			var err error
+			sm, err = dynamicClient.Resource(serviceMonitorGVR).Namespace(operatorNsName).Get(
+				context.Background(),
+				serviceMonitorName,
+				metav1.GetOptions{},
+			)
+			g.Expect(err).ToNot(HaveOccurred(), "ServiceMonitor should exist in operator namespace")
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+	})
+
+	It("should have correct dynamic serverName matching the operator namespace", func() {
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue(), "spec should have endpoints")
+		Expect(endpoints).ToNot(BeEmpty())
+
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should be a map")
+
+		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should have tlsConfig")
+
+		expectedServerName := fmt.Sprintf("%s.%s.svc", serviceName, operatorNsName)
+		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName),
+			"serverName must be dynamically constructed from the operator namespace, not hardcoded")
+	})
+
+	It("should have cluster-monitoring label on operator namespace", func() {
+		ns, err := clientSet.CoreV1().Namespaces().Get(context.Background(), operatorNsName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ns.Labels).To(HaveKeyWithValue("openshift.io/cluster-monitoring", "true"),
+			"operator namespace must be labeled for Prometheus discovery")
+	})
+
+	It("should have correct TLS CA configuration", func() {
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue())
+
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		ca, ok := tlsConfig["ca"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "tlsConfig should have ca")
+
+		configMap, ok := ca["configMap"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ca should have configMap")
+
+		Expect(configMap["name"]).To(Equal("node-healthcheck-ca-bundle"),
+			"CA ConfigMap name should reference the service-ca injected bundle")
+		Expect(configMap["key"]).To(Equal("service-ca.crt"))
+	})
+
+	It("should use the tls-client-certificate-auth scrape class", func() {
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		Expect(spec["scrapeClass"]).To(Equal("tls-client-certificate-auth"),
+			"scrapeClass must be set for Platform Prometheus mTLS")
+	})
+})

--- a/internal/controller/servicemonitor/monitor_test.go
+++ b/internal/controller/servicemonitor/monitor_test.go
@@ -68,7 +68,7 @@ func createTestNamespace(name string) {
 	ExpectWithOffset(1, k8sClient.Create(ctx, ns)).To(Succeed())
 }
 
-func uniqueNamespace(prefix string) string {
+func createUniqueNamespace(prefix string) string {
 	namespaceCounter++
 	name := fmt.Sprintf("%s-%d", prefix, namespaceCounter)
 	createTestNamespace(name)
@@ -219,7 +219,7 @@ var _ = Describe("getServiceMonitor", func() {
 
 var _ = Describe("createOrUpdateServiceMonitor", func() {
 	It("should create ServiceMonitor when it does not exist", func() {
-		namespace := uniqueNamespace("sm-create")
+		namespace := createUniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 
 		sm := getServiceMonitorFromCluster(namespace)
@@ -228,7 +228,7 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 
 	It("should update existing ServiceMonitor when called again", func() {
-		namespace := uniqueNamespace("sm-create")
+		namespace := createUniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 
 		// Verify no owner reference initially
@@ -254,7 +254,7 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 
 	It("should be idempotent when called multiple times", func() {
-		namespace := uniqueNamespace("sm-create")
+		namespace := createUniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
@@ -266,9 +266,9 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 
 	It("should produce different serverNames for different namespaces", func() {
 		// Core regression test: each namespace must get its own serverName, not a hardcoded one
-		ns1 := uniqueNamespace("ns-custom-a")
-		ns2 := uniqueNamespace("ns-custom-b")
-		ns3 := uniqueNamespace("ns-owa")
+		ns1 := createUniqueNamespace("ns-custom-a")
+		ns2 := createUniqueNamespace("ns-custom-b")
+		ns3 := createUniqueNamespace("ns-owa")
 		for _, ns := range []string{ns1, ns2, ns3} {
 			Expect(createOrUpdateServiceMonitor(ctx, ns, k8sClient, nil)).To(Succeed())
 		}
@@ -284,7 +284,7 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 
 var _ = Describe("labelNamespace", func() {
 	It("should add cluster-monitoring label to namespace", func() {
-		namespace := uniqueNamespace("sm-label")
+		namespace := createUniqueNamespace("sm-label")
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 
 		ns := &corev1.Namespace{}
@@ -293,7 +293,7 @@ var _ = Describe("labelNamespace", func() {
 	})
 
 	It("should be idempotent when label already exists", func() {
-		namespace := uniqueNamespace("sm-label")
+		namespace := createUniqueNamespace("sm-label")
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 
@@ -303,7 +303,7 @@ var _ = Describe("labelNamespace", func() {
 	})
 
 	It("should not overwrite existing namespace labels", func() {
-		namespace := uniqueNamespace("sm-label")
+		namespace := createUniqueNamespace("sm-label")
 		// Pre-label the namespace with a custom label
 		ns := &corev1.Namespace{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
@@ -348,7 +348,7 @@ var _ = Describe("CreateOrUpdate integration", func() {
 	})
 
 	It("should skip ServiceMonitor creation on non-OpenShift clusters", func() {
-		namespace := uniqueNamespace("sm-integration")
+		namespace := createUniqueNamespace("sm-integration")
 		caps := cluster.Capabilities{IsOnOpenshift: false}
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
 
@@ -371,7 +371,7 @@ var _ = Describe("CreateOrUpdate integration", func() {
 	})
 
 	It("should create ServiceMonitor and label namespace on OpenShift", func() {
-		namespace := uniqueNamespace("sm-integration")
+		namespace := createUniqueNamespace("sm-integration")
 		caps := cluster.Capabilities{IsOnOpenshift: true}
 		// POD_NAME not set — owner reference will be skipped gracefully
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
@@ -388,7 +388,7 @@ var _ = Describe("CreateOrUpdate integration", func() {
 	})
 
 	It("should create ServiceMonitor with correct serverName in custom namespace", func() {
-		customNs := uniqueNamespace("my-custom-operator-ns")
+		customNs := createUniqueNamespace("my-custom-operator-ns")
 
 		caps := cluster.Capabilities{IsOnOpenshift: true}
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, customNs, log)).To(Succeed())
@@ -401,8 +401,8 @@ var _ = Describe("CreateOrUpdate integration", func() {
 
 	When("called for both default and custom namespaces", func() {
 		It("should produce distinct serverNames per namespace", func() {
-			defaultNs := uniqueNamespace("openshift-wa")
-			customNs := uniqueNamespace("customer-ns")
+			defaultNs := createUniqueNamespace("openshift-wa")
+			customNs := createUniqueNamespace("customer-ns")
 
 			caps := cluster.Capabilities{IsOnOpenshift: true}
 			Expect(CreateOrUpdate(ctx, k8sClient, caps, defaultNs, log)).To(Succeed())

--- a/internal/controller/servicemonitor/monitor_test.go
+++ b/internal/controller/servicemonitor/monitor_test.go
@@ -17,177 +17,404 @@ limitations under the License.
 package servicemonitor
 
 import (
-	"context"
-	"testing"
+	"fmt"
+	"os"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/medik8s/node-healthcheck-operator/internal/controller/cluster"
 )
 
-func TestServiceMonitor(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "ServiceMonitor Suite")
+// getServiceMonitorFromCluster fetches the ServiceMonitor from the cluster and returns its spec fields
+func getServiceMonitorFromCluster(namespace string) *unstructured.Unstructured {
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ServiceMonitorName}, sm)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return sm
 }
 
-var _ = Describe("ServiceMonitor", func() {
-	var ctx context.Context
-	var log logr.Logger
+func getServerNameFromServiceMonitor(sm *unstructured.Unstructured) string {
+	spec := sm.Object["spec"].(map[string]interface{})
+	endpoints := spec["endpoints"].([]interface{})
+	endpoint := endpoints[0].(map[string]interface{})
+	tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+	return tlsConfig["serverName"].(string)
+}
+
+func createTestNamespace(name string) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	ExpectWithOffset(1, k8sClient.Create(ctx, ns)).To(Succeed())
+}
+
+// --- Existing unit tests for getServiceMonitor (pure function, no envtest needed) ---
+
+var _ = Describe("getServiceMonitor", func() {
+	It("should create ServiceMonitor with correct metadata", func() {
+		namespace := "test-namespace"
+		sm := getServiceMonitor(namespace, nil)
+
+		Expect(sm.GetName()).To(Equal(ServiceMonitorName))
+		Expect(sm.GetNamespace()).To(Equal(namespace))
+		Expect(sm.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/component", "controller-manager"))
+	})
+
+	It("should create ServiceMonitor with correct scrape class", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		Expect(spec["scrapeClass"]).To(Equal(ScrapeClass))
+	})
+
+	It("should create ServiceMonitor with correct label selectors", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		selector := spec["selector"].(map[string]interface{})
+		matchLabels := selector["matchLabels"].(map[string]interface{})
+
+		Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "controller-manager"))
+		Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "node-healthcheck-operator"))
+		Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "metrics"))
+	})
+
+	It("should create ServiceMonitor with correct endpoint configuration", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		endpoints := spec["endpoints"].([]interface{})
+		Expect(endpoints).To(HaveLen(1))
+
+		endpoint := endpoints[0].(map[string]interface{})
+		Expect(endpoint["port"]).To(Equal(MetricsPort))
+		Expect(endpoint["scheme"]).To(Equal(MetricsScheme))
+		Expect(endpoint["interval"]).To(Equal(ScrapeInterval))
+	})
+
+	It("should construct dynamic serverName from namespace", func() {
+		namespace := "custom-namespace"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		endpoints := spec["endpoints"].([]interface{})
+		endpoint := endpoints[0].(map[string]interface{})
+		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+
+		expectedServerName := "node-healthcheck-controller-manager-metrics-service.custom-namespace.svc"
+		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
+	})
+
+	It("should set CA ConfigMap correctly", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		endpoints := spec["endpoints"].([]interface{})
+		endpoint := endpoints[0].(map[string]interface{})
+		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+		ca := tlsConfig["ca"].(map[string]interface{})
+		configMap := ca["configMap"].(map[string]interface{})
+
+		Expect(configMap["name"]).To(Equal(CAConfigMapName))
+		Expect(configMap["key"]).To(Equal(CAConfigMapKey))
+	})
+
+	It("should use correct ServiceMonitor name", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		Expect(sm.GetName()).To(Equal("node-healthcheck-controller-manager-metrics-monitor"))
+	})
+
+	It("should work with default namespace", func() {
+		namespace := "openshift-workload-availability"
+		sm := getServiceMonitor(namespace, nil)
+
+		spec := sm.Object["spec"].(map[string]interface{})
+		endpoints := spec["endpoints"].([]interface{})
+		endpoint := endpoints[0].(map[string]interface{})
+		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+
+		expectedServerName := "node-healthcheck-controller-manager-metrics-service.openshift-workload-availability.svc"
+		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
+	})
+
+	It("should set owner reference when deployment is provided", func() {
+		namespace := "default"
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-healthcheck-controller-manager",
+				Namespace: namespace,
+				UID:       types.UID("test-uid-12345"),
+			},
+		}
+		sm := getServiceMonitor(namespace, deployment)
+
+		ownerRefs := sm.GetOwnerReferences()
+		Expect(ownerRefs).To(HaveLen(1))
+		Expect(ownerRefs[0].Kind).To(Equal("Deployment"))
+		Expect(ownerRefs[0].Name).To(Equal("node-healthcheck-controller-manager"))
+		Expect(ownerRefs[0].UID).To(Equal(types.UID("test-uid-12345")))
+		Expect(*ownerRefs[0].Controller).To(BeTrue())
+	})
+
+	It("should not set owner reference when deployment is nil", func() {
+		namespace := "default"
+		sm := getServiceMonitor(namespace, nil)
+
+		ownerRefs := sm.GetOwnerReferences()
+		Expect(ownerRefs).To(BeEmpty())
+	})
+})
+
+var _ = Describe("Constants", func() {
+	It("should have correct constant values", func() {
+		Expect(ServiceName).To(Equal("node-healthcheck-controller-manager-metrics-service"))
+		Expect(CAConfigMapName).To(Equal("node-healthcheck-ca-bundle"))
+		Expect(CAConfigMapKey).To(Equal("service-ca.crt"))
+		Expect(MetricsPort).To(Equal("https"))
+		Expect(MetricsScheme).To(Equal("https"))
+		Expect(ScrapeInterval).To(Equal("15s"))
+		Expect(ScrapeClass).To(Equal("tls-client-certificate-auth"))
+		Expect(ClusterMonitoringLabel).To(Equal("openshift.io/cluster-monitoring"))
+		Expect(ClusterMonitoringValue).To(Equal("true"))
+	})
+})
+
+// --- New envtest-based tests for createOrUpdateServiceMonitor ---
+
+var _ = Describe("createOrUpdateServiceMonitor", func() {
+	var namespace string
+	var testIndex int
 
 	BeforeEach(func() {
-		ctx = context.Background()
-		log = ctrl.Log.WithName("servicemonitor-test")
+		testIndex++
+		namespace = fmt.Sprintf("sm-create-test-%d", testIndex)
+		createTestNamespace(namespace)
 	})
 
-	Describe("CreateOrUpdate", func() {
-		When("on non-OpenShift cluster", func() {
-			It("should skip creation and return nil", func() {
-				caps := cluster.Capabilities{IsOnOpenshift: false}
-				err := CreateOrUpdate(ctx, nil, caps, "test-namespace", log)
-				Expect(err).To(BeNil())
-			})
-		})
+	It("should create ServiceMonitor when it does not exist", func() {
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
+
+		sm := getServiceMonitorFromCluster(namespace)
+		expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, namespace)
+		Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName))
 	})
 
-	Describe("getServiceMonitor", func() {
-		It("should create ServiceMonitor with correct metadata", func() {
-			namespace := "test-namespace"
-			sm := getServiceMonitor(namespace, nil)
+	It("should update existing ServiceMonitor when called again", func() {
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 
-			Expect(sm.GetName()).To(Equal(ServiceMonitorName))
-			Expect(sm.GetNamespace()).To(Equal(namespace))
-			Expect(sm.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/component", "controller-manager"))
-		})
+		// Verify no owner reference initially
+		sm := getServiceMonitorFromCluster(namespace)
+		Expect(sm.GetOwnerReferences()).To(BeEmpty())
 
-		It("should create ServiceMonitor with correct scrape class", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
+		// Update with a deployment owner
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: namespace,
+				UID:       types.UID("update-test-uid"),
+			},
+		}
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, deployment)).To(Succeed())
 
-			spec := sm.Object["spec"].(map[string]interface{})
-			Expect(spec["scrapeClass"]).To(Equal(ScrapeClass))
-		})
-
-		It("should create ServiceMonitor with correct label selectors", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
-
-			spec := sm.Object["spec"].(map[string]interface{})
-			selector := spec["selector"].(map[string]interface{})
-			matchLabels := selector["matchLabels"].(map[string]interface{})
-
-			Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "controller-manager"))
-			Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "node-healthcheck-operator"))
-			Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "metrics"))
-		})
-
-		It("should create ServiceMonitor with correct endpoint configuration", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
-
-			spec := sm.Object["spec"].(map[string]interface{})
-			endpoints := spec["endpoints"].([]interface{})
-			Expect(endpoints).To(HaveLen(1))
-
-			endpoint := endpoints[0].(map[string]interface{})
-			Expect(endpoint["port"]).To(Equal(MetricsPort))
-			Expect(endpoint["scheme"]).To(Equal(MetricsScheme))
-			Expect(endpoint["interval"]).To(Equal(ScrapeInterval))
-		})
-
-		It("should construct dynamic serverName from namespace", func() {
-			namespace := "custom-namespace"
-			sm := getServiceMonitor(namespace, nil)
-
-			spec := sm.Object["spec"].(map[string]interface{})
-			endpoints := spec["endpoints"].([]interface{})
-			endpoint := endpoints[0].(map[string]interface{})
-			tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
-
-			expectedServerName := "node-healthcheck-controller-manager-metrics-service.custom-namespace.svc"
-			Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
-		})
-
-		It("should set CA ConfigMap correctly", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
-
-			spec := sm.Object["spec"].(map[string]interface{})
-			endpoints := spec["endpoints"].([]interface{})
-			endpoint := endpoints[0].(map[string]interface{})
-			tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
-			ca := tlsConfig["ca"].(map[string]interface{})
-			configMap := ca["configMap"].(map[string]interface{})
-
-			Expect(configMap["name"]).To(Equal(CAConfigMapName))
-			Expect(configMap["key"]).To(Equal(CAConfigMapKey))
-		})
-
-		It("should use correct ServiceMonitor name", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
-
-			Expect(sm.GetName()).To(Equal("node-healthcheck-controller-manager-metrics-monitor"))
-		})
-
-		It("should work with default namespace", func() {
-			namespace := "openshift-workload-availability"
-			sm := getServiceMonitor(namespace, nil)
-
-			spec := sm.Object["spec"].(map[string]interface{})
-			endpoints := spec["endpoints"].([]interface{})
-			endpoint := endpoints[0].(map[string]interface{})
-			tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
-
-			expectedServerName := "node-healthcheck-controller-manager-metrics-service.openshift-workload-availability.svc"
-			Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
-		})
-
-		It("should set owner reference when deployment is provided", func() {
-			namespace := "default"
-			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "node-healthcheck-controller-manager",
-					Namespace: namespace,
-					UID:       types.UID("test-uid-12345"),
-				},
-			}
-			sm := getServiceMonitor(namespace, deployment)
-
-			ownerRefs := sm.GetOwnerReferences()
-			Expect(ownerRefs).To(HaveLen(1))
-			Expect(ownerRefs[0].Kind).To(Equal("Deployment"))
-			Expect(ownerRefs[0].Name).To(Equal("node-healthcheck-controller-manager"))
-			Expect(ownerRefs[0].UID).To(Equal(types.UID("test-uid-12345")))
-			Expect(*ownerRefs[0].Controller).To(BeTrue())
-		})
-
-		It("should not set owner reference when deployment is nil", func() {
-			namespace := "default"
-			sm := getServiceMonitor(namespace, nil)
-
-			ownerRefs := sm.GetOwnerReferences()
-			Expect(ownerRefs).To(BeEmpty())
-		})
+		// Verify owner reference was added
+		sm = getServiceMonitorFromCluster(namespace)
+		ownerRefs := sm.GetOwnerReferences()
+		Expect(ownerRefs).To(HaveLen(1))
+		Expect(ownerRefs[0].Name).To(Equal("test-deployment"))
+		Expect(ownerRefs[0].UID).To(Equal(types.UID("update-test-uid")))
 	})
 
-	Describe("Constants", func() {
-		It("should have correct constant values", func() {
-			Expect(ServiceName).To(Equal("node-healthcheck-controller-manager-metrics-service"))
-			Expect(CAConfigMapName).To(Equal("node-healthcheck-ca-bundle"))
-			Expect(CAConfigMapKey).To(Equal("service-ca.crt"))
-			Expect(MetricsPort).To(Equal("https"))
-			Expect(MetricsScheme).To(Equal("https"))
-			Expect(ScrapeInterval).To(Equal("15s"))
-			Expect(ScrapeClass).To(Equal("tls-client-certificate-auth"))
-			Expect(ClusterMonitoringLabel).To(Equal("openshift.io/cluster-monitoring"))
-			Expect(ClusterMonitoringValue).To(Equal("true"))
+	It("should be idempotent when called multiple times", func() {
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
+		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
+
+		sm := getServiceMonitorFromCluster(namespace)
+		expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, namespace)
+		Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName))
+	})
+
+	It("should produce different serverNames for different namespaces", func() {
+		// This is the core regression test for RHWA-906:
+		// each namespace must get its own serverName, not a hardcoded one
+		namespaces := []string{
+			fmt.Sprintf("ns-custom-a-%d", testIndex),
+			fmt.Sprintf("ns-custom-b-%d", testIndex),
+			fmt.Sprintf("ns-owa-%d", testIndex),
+		}
+		for _, ns := range namespaces {
+			createTestNamespace(ns)
+			Expect(createOrUpdateServiceMonitor(ctx, ns, k8sClient, nil)).To(Succeed())
+		}
+
+		for _, ns := range namespaces {
+			sm := getServiceMonitorFromCluster(ns)
+			expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, ns)
+			Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName),
+				"serverName mismatch for namespace %s", ns)
+		}
+	})
+})
+
+// --- New envtest-based tests for labelNamespace ---
+
+var _ = Describe("labelNamespace", func() {
+	var namespace string
+	var testIndex int
+
+	BeforeEach(func() {
+		testIndex++
+		namespace = fmt.Sprintf("sm-label-test-%d", testIndex)
+		createTestNamespace(namespace)
+	})
+
+	It("should add cluster-monitoring label to namespace", func() {
+		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
+
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		Expect(ns.Labels).To(HaveKeyWithValue(ClusterMonitoringLabel, ClusterMonitoringValue))
+	})
+
+	It("should be idempotent when label already exists", func() {
+		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
+		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
+
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		Expect(ns.Labels).To(HaveKeyWithValue(ClusterMonitoringLabel, ClusterMonitoringValue))
+	})
+
+	It("should not overwrite existing namespace labels", func() {
+		// Pre-label the namespace with a custom label
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		base := ns.DeepCopy()
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels["custom-label"] = "custom-value"
+		Expect(k8sClient.Patch(ctx, ns, client.MergeFrom(base))).To(Succeed())
+
+		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		Expect(ns.Labels).To(HaveKeyWithValue(ClusterMonitoringLabel, ClusterMonitoringValue))
+		Expect(ns.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
+	})
+
+	It("should return error for non-existent namespace", func() {
+		err := labelNamespace(ctx, "non-existent-namespace", k8sClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("could not fetch namespace"))
+	})
+})
+
+// --- New envtest-based integration test for CreateOrUpdate ---
+
+var _ = Describe("CreateOrUpdate integration", func() {
+	var namespace string
+	var log logr.Logger
+	var testIndex int
+	var originalPodName string
+	var podNameWasSet bool
+
+	BeforeEach(func() {
+		testIndex++
+		namespace = fmt.Sprintf("sm-integration-test-%d", testIndex)
+		log = ctrl.Log.WithName("servicemonitor-integration-test")
+		createTestNamespace(namespace)
+		originalPodName, podNameWasSet = os.LookupEnv("POD_NAME")
+		os.Unsetenv("POD_NAME")
+	})
+
+	AfterEach(func() {
+		if podNameWasSet {
+			os.Setenv("POD_NAME", originalPodName)
+		} else {
+			os.Unsetenv("POD_NAME")
+		}
+	})
+
+	It("should skip ServiceMonitor creation on non-OpenShift clusters", func() {
+		caps := cluster.Capabilities{IsOnOpenshift: false}
+		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
+
+		// Verify no ServiceMonitor was created
+		sm := &unstructured.Unstructured{}
+		sm.SetGroupVersionKind(serviceMonitorGVK)
+		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ServiceMonitorName}, sm)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("should create ServiceMonitor and label namespace on OpenShift", func() {
+		caps := cluster.Capabilities{IsOnOpenshift: true}
+		// POD_NAME not set — owner reference will be skipped gracefully
+		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
+
+		// Verify ServiceMonitor exists with correct serverName
+		sm := getServiceMonitorFromCluster(namespace)
+		expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, namespace)
+		Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName))
+
+		// Verify namespace was labeled
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		Expect(ns.Labels).To(HaveKeyWithValue(ClusterMonitoringLabel, ClusterMonitoringValue))
+	})
+
+	It("should create ServiceMonitor with correct serverName in custom namespace", func() {
+		customNs := fmt.Sprintf("my-custom-operator-ns-%d", testIndex)
+		createTestNamespace(customNs)
+
+		caps := cluster.Capabilities{IsOnOpenshift: true}
+		Expect(CreateOrUpdate(ctx, k8sClient, caps, customNs, log)).To(Succeed())
+
+		sm := getServiceMonitorFromCluster(customNs)
+		expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, customNs)
+		Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName),
+			"serverName must reflect the custom namespace, not a hardcoded default")
+	})
+
+	When("called for both default and custom namespaces", func() {
+		It("should produce distinct serverNames per namespace", func() {
+			defaultNs := fmt.Sprintf("openshift-wa-%d", testIndex)
+			customNs := fmt.Sprintf("customer-ns-%d", testIndex)
+			createTestNamespace(defaultNs)
+			createTestNamespace(customNs)
+
+			caps := cluster.Capabilities{IsOnOpenshift: true}
+			Expect(CreateOrUpdate(ctx, k8sClient, caps, defaultNs, log)).To(Succeed())
+			Expect(CreateOrUpdate(ctx, k8sClient, caps, customNs, log)).To(Succeed())
+
+			smDefault := getServiceMonitorFromCluster(defaultNs)
+			smCustom := getServiceMonitorFromCluster(customNs)
+
+			Expect(getServerNameFromServiceMonitor(smDefault)).To(
+				Equal(fmt.Sprintf("%s.%s.svc", ServiceName, defaultNs)))
+			Expect(getServerNameFromServiceMonitor(smCustom)).To(
+				Equal(fmt.Sprintf("%s.%s.svc", ServiceName, customNs)))
+			Expect(getServerNameFromServiceMonitor(smDefault)).ToNot(
+				Equal(getServerNameFromServiceMonitor(smCustom)),
+				"serverNames must differ across namespaces")
 		})
 	})
 })

--- a/internal/controller/servicemonitor/monitor_test.go
+++ b/internal/controller/servicemonitor/monitor_test.go
@@ -45,12 +45,21 @@ func getServiceMonitorFromCluster(namespace string) *unstructured.Unstructured {
 }
 
 func getServerNameFromServiceMonitor(sm *unstructured.Unstructured) string {
-	spec := sm.Object["spec"].(map[string]interface{})
-	endpoints := spec["endpoints"].([]interface{})
-	endpoint := endpoints[0].(map[string]interface{})
-	tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
-	return tlsConfig["serverName"].(string)
+	spec, ok := sm.Object["spec"].(map[string]interface{})
+	ExpectWithOffset(1, ok).To(BeTrue(), "ServiceMonitor should have a spec")
+	endpoints, ok := spec["endpoints"].([]interface{})
+	ExpectWithOffset(1, ok).To(BeTrue(), "spec should have endpoints")
+	ExpectWithOffset(1, endpoints).ToNot(BeEmpty())
+	endpoint, ok := endpoints[0].(map[string]interface{})
+	ExpectWithOffset(1, ok).To(BeTrue(), "endpoint should be a map")
+	tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+	ExpectWithOffset(1, ok).To(BeTrue(), "endpoint should have tlsConfig")
+	serverName, ok := tlsConfig["serverName"].(string)
+	ExpectWithOffset(1, ok).To(BeTrue(), "tlsConfig should have serverName")
+	return serverName
 }
+
+var namespaceCounter int
 
 func createTestNamespace(name string) {
 	ns := &corev1.Namespace{
@@ -59,7 +68,12 @@ func createTestNamespace(name string) {
 	ExpectWithOffset(1, k8sClient.Create(ctx, ns)).To(Succeed())
 }
 
-// --- Existing unit tests for getServiceMonitor (pure function, no envtest needed) ---
+func uniqueNamespace(prefix string) string {
+	namespaceCounter++
+	name := fmt.Sprintf("%s-%d", prefix, namespaceCounter)
+	createTestNamespace(name)
+	return name
+}
 
 var _ = Describe("getServiceMonitor", func() {
 	It("should create ServiceMonitor with correct metadata", func() {
@@ -75,7 +89,8 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "default"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
 		Expect(spec["scrapeClass"]).To(Equal(ScrapeClass))
 	})
 
@@ -83,9 +98,12 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "default"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
-		selector := spec["selector"].(map[string]interface{})
-		matchLabels := selector["matchLabels"].(map[string]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+		selector, ok := spec["selector"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "spec should have selector")
+		matchLabels, ok := selector["matchLabels"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "selector should have matchLabels")
 
 		Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "controller-manager"))
 		Expect(matchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "node-healthcheck-operator"))
@@ -96,11 +114,14 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "default"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
-		endpoints := spec["endpoints"].([]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue(), "spec should have endpoints")
 		Expect(endpoints).To(HaveLen(1))
 
-		endpoint := endpoints[0].(map[string]interface{})
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should be a map")
 		Expect(endpoint["port"]).To(Equal(MetricsPort))
 		Expect(endpoint["scheme"]).To(Equal(MetricsScheme))
 		Expect(endpoint["interval"]).To(Equal(ScrapeInterval))
@@ -110,10 +131,14 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "custom-namespace"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
-		endpoints := spec["endpoints"].([]interface{})
-		endpoint := endpoints[0].(map[string]interface{})
-		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue(), "spec should have endpoints")
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should be a map")
+		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should have tlsConfig")
 
 		expectedServerName := "node-healthcheck-controller-manager-metrics-service.custom-namespace.svc"
 		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
@@ -123,12 +148,18 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "default"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
-		endpoints := spec["endpoints"].([]interface{})
-		endpoint := endpoints[0].(map[string]interface{})
-		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
-		ca := tlsConfig["ca"].(map[string]interface{})
-		configMap := ca["configMap"].(map[string]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue(), "spec should have endpoints")
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should be a map")
+		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should have tlsConfig")
+		ca, ok := tlsConfig["ca"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "tlsConfig should have ca")
+		configMap, ok := ca["configMap"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ca should have configMap")
 
 		Expect(configMap["name"]).To(Equal(CAConfigMapName))
 		Expect(configMap["key"]).To(Equal(CAConfigMapKey))
@@ -145,10 +176,14 @@ var _ = Describe("getServiceMonitor", func() {
 		namespace := "openshift-workload-availability"
 		sm := getServiceMonitor(namespace, nil)
 
-		spec := sm.Object["spec"].(map[string]interface{})
-		endpoints := spec["endpoints"].([]interface{})
-		endpoint := endpoints[0].(map[string]interface{})
-		tlsConfig := endpoint["tlsConfig"].(map[string]interface{})
+		spec, ok := sm.Object["spec"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "ServiceMonitor should have a spec")
+		endpoints, ok := spec["endpoints"].([]interface{})
+		Expect(ok).To(BeTrue(), "spec should have endpoints")
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should be a map")
+		tlsConfig, ok := endpoint["tlsConfig"].(map[string]interface{})
+		Expect(ok).To(BeTrue(), "endpoint should have tlsConfig")
 
 		expectedServerName := "node-healthcheck-controller-manager-metrics-service.openshift-workload-availability.svc"
 		Expect(tlsConfig["serverName"]).To(Equal(expectedServerName))
@@ -182,33 +217,9 @@ var _ = Describe("getServiceMonitor", func() {
 	})
 })
 
-var _ = Describe("Constants", func() {
-	It("should have correct constant values", func() {
-		Expect(ServiceName).To(Equal("node-healthcheck-controller-manager-metrics-service"))
-		Expect(CAConfigMapName).To(Equal("node-healthcheck-ca-bundle"))
-		Expect(CAConfigMapKey).To(Equal("service-ca.crt"))
-		Expect(MetricsPort).To(Equal("https"))
-		Expect(MetricsScheme).To(Equal("https"))
-		Expect(ScrapeInterval).To(Equal("15s"))
-		Expect(ScrapeClass).To(Equal("tls-client-certificate-auth"))
-		Expect(ClusterMonitoringLabel).To(Equal("openshift.io/cluster-monitoring"))
-		Expect(ClusterMonitoringValue).To(Equal("true"))
-	})
-})
-
-// --- New envtest-based tests for createOrUpdateServiceMonitor ---
-
 var _ = Describe("createOrUpdateServiceMonitor", func() {
-	var namespace string
-	var testIndex int
-
-	BeforeEach(func() {
-		testIndex++
-		namespace = fmt.Sprintf("sm-create-test-%d", testIndex)
-		createTestNamespace(namespace)
-	})
-
 	It("should create ServiceMonitor when it does not exist", func() {
+		namespace := uniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 
 		sm := getServiceMonitorFromCluster(namespace)
@@ -217,6 +228,7 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 
 	It("should update existing ServiceMonitor when called again", func() {
+		namespace := uniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 
 		// Verify no owner reference initially
@@ -242,6 +254,7 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 
 	It("should be idempotent when called multiple times", func() {
+		namespace := uniqueNamespace("sm-create")
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
 		Expect(createOrUpdateServiceMonitor(ctx, namespace, k8sClient, nil)).To(Succeed())
@@ -252,19 +265,15 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 
 	It("should produce different serverNames for different namespaces", func() {
-		// This is the core regression test for RHWA-906:
-		// each namespace must get its own serverName, not a hardcoded one
-		namespaces := []string{
-			fmt.Sprintf("ns-custom-a-%d", testIndex),
-			fmt.Sprintf("ns-custom-b-%d", testIndex),
-			fmt.Sprintf("ns-owa-%d", testIndex),
-		}
-		for _, ns := range namespaces {
-			createTestNamespace(ns)
+		// Core regression test: each namespace must get its own serverName, not a hardcoded one
+		ns1 := uniqueNamespace("ns-custom-a")
+		ns2 := uniqueNamespace("ns-custom-b")
+		ns3 := uniqueNamespace("ns-owa")
+		for _, ns := range []string{ns1, ns2, ns3} {
 			Expect(createOrUpdateServiceMonitor(ctx, ns, k8sClient, nil)).To(Succeed())
 		}
 
-		for _, ns := range namespaces {
+		for _, ns := range []string{ns1, ns2, ns3} {
 			sm := getServiceMonitorFromCluster(ns)
 			expectedServerName := fmt.Sprintf("%s.%s.svc", ServiceName, ns)
 			Expect(getServerNameFromServiceMonitor(sm)).To(Equal(expectedServerName),
@@ -273,19 +282,9 @@ var _ = Describe("createOrUpdateServiceMonitor", func() {
 	})
 })
 
-// --- New envtest-based tests for labelNamespace ---
-
 var _ = Describe("labelNamespace", func() {
-	var namespace string
-	var testIndex int
-
-	BeforeEach(func() {
-		testIndex++
-		namespace = fmt.Sprintf("sm-label-test-%d", testIndex)
-		createTestNamespace(namespace)
-	})
-
 	It("should add cluster-monitoring label to namespace", func() {
+		namespace := uniqueNamespace("sm-label")
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 
 		ns := &corev1.Namespace{}
@@ -294,6 +293,7 @@ var _ = Describe("labelNamespace", func() {
 	})
 
 	It("should be idempotent when label already exists", func() {
+		namespace := uniqueNamespace("sm-label")
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 		Expect(labelNamespace(ctx, namespace, k8sClient)).To(Succeed())
 
@@ -303,6 +303,7 @@ var _ = Describe("labelNamespace", func() {
 	})
 
 	It("should not overwrite existing namespace labels", func() {
+		namespace := uniqueNamespace("sm-label")
 		// Pre-label the namespace with a custom label
 		ns := &corev1.Namespace{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
@@ -327,20 +328,13 @@ var _ = Describe("labelNamespace", func() {
 	})
 })
 
-// --- New envtest-based integration test for CreateOrUpdate ---
-
 var _ = Describe("CreateOrUpdate integration", func() {
-	var namespace string
 	var log logr.Logger
-	var testIndex int
 	var originalPodName string
 	var podNameWasSet bool
 
 	BeforeEach(func() {
-		testIndex++
-		namespace = fmt.Sprintf("sm-integration-test-%d", testIndex)
 		log = ctrl.Log.WithName("servicemonitor-integration-test")
-		createTestNamespace(namespace)
 		originalPodName, podNameWasSet = os.LookupEnv("POD_NAME")
 		os.Unsetenv("POD_NAME")
 	})
@@ -354,6 +348,7 @@ var _ = Describe("CreateOrUpdate integration", func() {
 	})
 
 	It("should skip ServiceMonitor creation on non-OpenShift clusters", func() {
+		namespace := uniqueNamespace("sm-integration")
 		caps := cluster.Capabilities{IsOnOpenshift: false}
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
 
@@ -363,9 +358,20 @@ var _ = Describe("CreateOrUpdate integration", func() {
 		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ServiceMonitorName}, sm)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
+
+		// Verify namespace was NOT labeled for cluster monitoring
+		ns := &corev1.Namespace{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)).To(Succeed())
+		Expect(ns.Labels).ToNot(HaveKey(ClusterMonitoringLabel))
+	})
+
+	It("should skip with nil client on non-OpenShift", func() {
+		caps := cluster.Capabilities{IsOnOpenshift: false}
+		Expect(CreateOrUpdate(ctx, nil, caps, "any-namespace", log)).To(Succeed())
 	})
 
 	It("should create ServiceMonitor and label namespace on OpenShift", func() {
+		namespace := uniqueNamespace("sm-integration")
 		caps := cluster.Capabilities{IsOnOpenshift: true}
 		// POD_NAME not set — owner reference will be skipped gracefully
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, namespace, log)).To(Succeed())
@@ -382,8 +388,7 @@ var _ = Describe("CreateOrUpdate integration", func() {
 	})
 
 	It("should create ServiceMonitor with correct serverName in custom namespace", func() {
-		customNs := fmt.Sprintf("my-custom-operator-ns-%d", testIndex)
-		createTestNamespace(customNs)
+		customNs := uniqueNamespace("my-custom-operator-ns")
 
 		caps := cluster.Capabilities{IsOnOpenshift: true}
 		Expect(CreateOrUpdate(ctx, k8sClient, caps, customNs, log)).To(Succeed())
@@ -396,10 +401,8 @@ var _ = Describe("CreateOrUpdate integration", func() {
 
 	When("called for both default and custom namespaces", func() {
 		It("should produce distinct serverNames per namespace", func() {
-			defaultNs := fmt.Sprintf("openshift-wa-%d", testIndex)
-			customNs := fmt.Sprintf("customer-ns-%d", testIndex)
-			createTestNamespace(defaultNs)
-			createTestNamespace(customNs)
+			defaultNs := uniqueNamespace("openshift-wa")
+			customNs := uniqueNamespace("customer-ns")
 
 			caps := cluster.Capabilities{IsOnOpenshift: true}
 			Expect(CreateOrUpdate(ctx, k8sClient, caps, defaultNs, log)).To(Succeed())

--- a/internal/controller/servicemonitor/suite_test.go
+++ b/internal/controller/servicemonitor/suite_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicemonitor
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestServiceMonitor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ServiceMonitor Suite")
+}
+
+var _ = BeforeSuite(func() {
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
+	}
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
+
+	By("bootstrapping test environment with ServiceMonitor CRD")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths:              []string{"testdata"},
+			ErrorIfPathMissing: true,
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(appsv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(corev1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	ctx, cancel = context.WithCancel(context.Background())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/internal/controller/servicemonitor/testdata/servicemonitor-crd.yaml
+++ b/internal/controller/servicemonitor/testdata/servicemonitor-crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Summary

Add test coverage for the [RHWA-906](https://redhat.atlassian.net/browse/RHWA-906)

The static ServiceMonitor manifest had a hardcoded `openshift-workload-availability` in TLS serverName, causing Prometheus scraping failures when deployed to a custom namespace. This was fixed by replacing it with programmatic creation at operator startup. The fix shipped with minimal test coverage — only the spec builder (`getServiceMonitor`) and the non-OCP skip path were tested.

This PR adds the missing coverage:

- **`createOrUpdateServiceMonitor`** — verifies create, update, and idempotency against a real API server (envtest)
- **`labelNamespace`** — verifies cluster-monitoring label is applied, is idempotent, and preserves existing labels
- **`CreateOrUpdate` integration** — exercises the full OCP path end-to-end within envtest, confirming serverName is dynamically derived from the deployment namespace
- **E2e (OCP-only)** — validates ServiceMonitor exists on a live cluster with correct serverName, TLS CA config, scrapeClass, and namespace label

All 23 unit tests pass locally. E2e tests are labeled `OCP-ONLY`.

## Test plan

- [x] `make test` — unit tests pass (envtest)
- [ ] E2e on OCP cluster with `OPERATOR_NS` set — verify ServiceMonitor specs match deployment namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)