### PR TITLE
Add NetworkPolicy RBAC permission

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -411,6 +411,14 @@ spec:
           - list
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - policy
           resources:
           - poddisruptionbudgets

--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -419,6 +419,14 @@ spec:
           - list
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - policy
           resources:
           - poddisruptionbudgets

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -100,6 +100,14 @@ rules:
   - list
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,6 +108,14 @@ rules:
   - list
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -133,6 +133,7 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // for the etcd check of github.com/medik8s/common/pkg/etcd
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -133,6 +133,7 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // for the etcd check of github.com/medik8s/common/pkg/etcd
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 // Events for cluster-scoped resources like NHC are always created in the "default" namespace, so we need cluster scoped permissions.
 // The leader election permissions cover the operator namespace only. That isn't an issue with OLM and AllNamespaces mode, because all


### PR DESCRIPTION
## Summary

Add `networking.k8s.io/networkpolicies` RBAC (create, delete, update) to allow managing NetworkPolicies for operand workloads.

## Changes

- Add kubebuilder RBAC marker to controller
- Regenerate `config/rbac/role.yaml`
- Regenerate bundle CSV

## Test plan

- [x] `make manifests` — RBAC generated correctly
- [x] `make bundle-reset` — bundle validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)