### PR TITLE
Add cluster-scoped RBAC for events

### DIFF
--- a/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-healthcheck-operator.clusterserviceversion.yaml
@@ -318,6 +318,13 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
           - namespaces
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create

--- a/e2e/nhc_e2e_test.go
+++ b/e2e/nhc_e2e_test.go
@@ -289,6 +289,15 @@ var _ = Describe("e2e - NHC", Label("NHC"), func() {
 						g.Expect(nhc.Status.Phase).To(Equal(v1alpha1.PhaseRemediating))
 					}, "10s", "500ms").Should(Succeed())
 
+					By("ensuring DetectedUnhealthy event was emitted")
+					Eventually(func(g Gomega) {
+						events, err := clientSet.CoreV1().Events("default").List(context.Background(), metav1.ListOptions{
+							FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=NodeHealthCheck,reason=DetectedUnhealthy", nhcName),
+						})
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(events.Items).ToNot(BeEmpty(), "expected DetectedUnhealthy event for NHC in default namespace")
+					}, "30s", "1s").Should(Succeed())
+
 					// let's do some NHC validation tests here
 					By("ensuring negative maxUnhealthy update fails")
 					nhc = getNodeHealthCheck()

--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -133,6 +133,10 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // for the etcd check of github.com/medik8s/common/pkg/etcd
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
+// Events for cluster-scoped resources like NHC are always created in the "default" namespace, so we need cluster scoped permissions.
+// The leader election permissions cover the operator namespace only. That isn't an issue with OLM and AllNamespaces mode, because all
+// permission are created cluster scoped automatically, but for other deployment methods.
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/nodehealthcheck_controller.go
+++ b/internal/controller/nodehealthcheck_controller.go
@@ -133,6 +133,7 @@ func (r *NodeHealthCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // for the etcd check of github.com/medik8s/common/pkg/etcd
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
#### Why we need this PR

Events for cluster-scoped `NodeHealthCheck` objects are created in the `default` namespace by client-go (hardcoded fallback for objects with no namespace). The RBAC for events is in `leader_election_role.yaml` — a namespace-scoped `Role` bound only in the operator's namespace. When the operator runs outside `default`, event creation fails silently:

```
E0809 07:40:56.782610       1 event.go:359] "Server rejected event (will not retry!)"
  err="events is forbidden: User \"system:serviceaccount:medik8s:node-healthcheck-controller-manager\"
  cannot create resource \"events\" in API group \"\" in the namespace \"default\""
```

The events RBAC ended up in the leader election Role because that's the kubebuilder scaffold default — it covers leader election's own events. Controller events against cluster-scoped objects need ClusterRole permissions, but the `//+kubebuilder:rbac` marker was never added. See the [kubebuilder docs on raising events](https://book.kubebuilder.io/reference/raising-events).

**Why OLM masks this bug:** NHC only supports `AllNamespaces` install mode. In this mode, OLM promotes all namespace-scoped `permissions` to ClusterRole + ClusterRoleBinding — effectively no difference from `clusterPermissions`. The leader election events RBAC gets silently elevated to cluster-wide, so events work under OLM. The bug only manifests with non-OLM deployments (`make deploy`), where the RBAC files are applied as written.

A namespace-scoped workaround (injecting the operator namespace into the event recorder) was considered but rejected because it would break `kubectl describe nodehealthcheck` (which looks for events in `default` for cluster-scoped objects) and would not work with OLM.

#### Changes made

- Added `//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch` marker on the NHC controller
- Regenerated `config/rbac/role.yaml` and bundle CSV with `make manifests bundle-base`
- Added e2e test asserting `DetectedUnhealthy` event is emitted after remediation starts (note: this test passes in CI because OLM's AllNamespaces promotion masks the bug, but it still validates event emission end-to-end)

#### Which issue(s) this PR fixes

Fixes #428

#### Test plan

- Unit tests pass (`make test`)
- The new e2e event assertion runs as part of the existing "Remediates a host and prevents config updates" test
- The RBAC fix cannot be verified in OLM-based CI (OLM masks the issue), but can be verified with `make deploy` on a cluster where the operator runs outside the `default` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)