### PR TITLE
Document certsuite best practices exceptions for NHC

### DIFF
--- a/docs/certsuite_exceptions.md
+++ b/docs/certsuite_exceptions.md
@@ -1,0 +1,52 @@
+# Certsuite Best Practices Exceptions for Node HealthCheck Operator
+
+This document justifies Node HealthCheck operator (NHC) configurations that deviate from Red Hat's [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite) (Cloud-native best practices test suite for Kubernetes workloads). The NHC operator follows these best practices where applicable, but requires specific exceptions that are architectural requirements for cluster-wide node health monitoring.
+
+---
+
+## 1. [`lifecycle-pod-toleration-bypass`](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#lifecycle-pod-toleration-bypass)
+
+The NHC operator uses non-default tolerations for master, control-plane, and infrastructure node taints because it must monitor **all nodes** in the cluster, not just worker nodes.
+
+### Justification
+
+Without these tolerations, control-plane and infrastructure nodes would lack health monitoring. In failure scenarios where all worker nodes are unhealthy, the operator must run on control-plane or infra nodes to perform its core function.
+
+The operator uses `priorityClassName: system-cluster-critical`, confirming its infrastructure-level role. All Medik8s node-monitoring operators (Node Maintenance Operator, Self Node Remediation) use identical tolerations.
+
+**Required tolerations:**
+```yaml
+tolerations:
+  - key: "node-role.kubernetes.io/master"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
+```
+
+---
+
+## 2. [`access-control-pod-role-bindings`](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#access-control-pod-role-bindings)
+
+The RoleBinding `service-auth-reader` in the `kube-system` namespace is automatically created by [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/) when the operator deploys admission webhooks. This binding is not defined in the operator's codebase and cannot be prevented.
+
+### Justification
+
+The NHC operator uses admission webhooks for `NodeHealthCheck` validation and defaulting. These webhooks require reading the `extension-apiserver-authentication` ConfigMap in `kube-system` for TLS authentication. This is the standard OLM pattern for all webhook-based operators ([Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers)).
+
+**RoleBinding details:**
+- **Name:** `node-healthcheck-controller-manager-service-auth-reader`
+- **Namespace:** `kube-system`
+- **Created by:** OLM (not the operator)
+
+---
+
+## Summary
+
+Both configurations are architectural requirements:
+- **Toleration-bypass:** Enables monitoring of all cluster nodes (control-plane, infra, worker)
+- **Pod-role-bindings:** Required by OLM for webhook TLS authentication; not under operator control

--- a/docs/certsuite_exceptions.md
+++ b/docs/certsuite_exceptions.md
@@ -12,6 +12,8 @@ The NHC operator uses non-default tolerations for master, control-plane, and inf
 
 Without these tolerations, control-plane and infrastructure nodes would lack health monitoring. In failure scenarios where all worker nodes are unhealthy, the operator must run on control-plane or infra nodes to perform its core function.
 
+The `NoExecute` toleration for infrastructure nodes prevents pod eviction during node pressure events, ensuring continuous monitoring even when the node is under resource constraints.
+
 The operator uses `priorityClassName: system-cluster-critical`, confirming its infrastructure-level role. All Medik8s node-monitoring operators (Node Maintenance Operator, Self Node Remediation) use identical tolerations.
 
 **Required tolerations:**
@@ -26,27 +28,34 @@ tolerations:
   - key: "node-role.kubernetes.io/infra"
     operator: "Exists"
     effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoExecute"
 ```
 
 ---
 
 ## 2. [`access-control-pod-role-bindings`](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#access-control-pod-role-bindings)
 
-The RoleBinding `service-auth-reader` in the `kube-system` namespace is automatically created by [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/) when the operator deploys admission webhooks. This binding is not defined in the operator's codebase and cannot be prevented.
+The RoleBinding `manager-rolebinding` in the `kube-system` namespace grants the operator read access to the `extension-apiserver-authentication` ConfigMap for metrics mTLS authentication.
 
 ### Justification
 
-The NHC operator uses admission webhooks for `NodeHealthCheck` validation and defaulting. These webhooks require reading the `extension-apiserver-authentication` ConfigMap in `kube-system` for TLS authentication. This is the standard OLM pattern for all webhook-based operators ([Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers)).
+The NHC operator serves metrics to Platform Prometheus via mTLS. The metrics server reads the cluster's client CA bundle from the `extension-apiserver-authentication` ConfigMap to verify Prometheus client certificates.
+
+This RoleBinding is defined in `config/optional/kube-system-rbac/` and follows the standard pattern for OpenShift operators serving authenticated metrics endpoints.
 
 **RoleBinding details:**
-- **Name:** `node-healthcheck-controller-manager-service-auth-reader`
+- **Name:** `manager-rolebinding`
 - **Namespace:** `kube-system`
-- **Created by:** OLM (not the operator)
+- **Role:** `manager-role` (grants get/list/watch on `extension-apiserver-authentication` ConfigMap)
+- **Purpose:** Read client CA bundle for metrics mTLS authentication
+- **Code reference:** `internal/metrics/tls/configure.go` (ConfigureMTLS function)
 
 ---
 
 ## Summary
 
 Both configurations are architectural requirements:
-- **Toleration-bypass:** Enables monitoring of all cluster nodes (control-plane, infra, worker)
-- **Pod-role-bindings:** Required by OLM for webhook TLS authentication; not under operator control
+- **Toleration-bypass:** Enables monitoring of all cluster nodes (control-plane, infra, worker). Includes `NoExecute` toleration for infra nodes to prevent eviction during node pressure.
+- **Pod-role-bindings:** Required for metrics mTLS authentication with Platform Prometheus


### PR DESCRIPTION
## Why

The NHC operator requires 2 specific configurations that deviate from [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite) best practices but are fundamental architectural requirements for cluster-wide node health monitoring:

1. **Non-default tolerations** (lifecycle-pod-toleration-bypass) — 4 tolerations needed to monitor all cluster nodes (control-plane, infra, worker), including a NoExecute toleration for infra nodes to prevent eviction during node pressure
2. **Cross-namespace RoleBinding** (access-control-pod-role-bindings) — `manager-rolebinding` in kube-system for metrics mTLS authentication with Platform Prometheus

## Changes

- Add `docs/certsuite_exceptions.md` documenting both exceptions with accurate technical details
- Links to public certsuite catalog and OLM documentation
- 61 lines, follows pattern from openshift/oadp-operator#1745
- All claims verified against actual repository manifests and code

## Issues

Related: [RHWA-1615](https://redhat.atlassian.net/browse/RHWA-1615)

## Test plan

Documentation only — no functional changes.

## Recent Updates

**ecc06d50** - Fixed documentation accuracy based on CodeRabbit findings:
- Added missing 4th toleration (NoExecute for infra nodes)
- Corrected RoleBinding name (manager-rolebinding, not service-auth-reader)
- Corrected purpose (metrics mTLS, not webhook authentication)
- Corrected ownership (defined in codebase at config/optional/kube-system-rbac/)